### PR TITLE
Azure: Sample apps: Terraform tests

### DIFF
--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -59,6 +59,12 @@ jobs:
           sudo apt-get install -y jq zip unixodbc-dev libsnappy-dev
           find . -name "*.sh" -exec chmod +x {} +
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+          terraform_wrapper: false
+
       - name: Install test dependencies
         # Mirroring the localstack-pro approach: install all Python dependencies 
         # (including the localstack CLI) into a virtual environment to avoid system-level conflicts.

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -23,8 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
-        splits: [2]
+        shard: [1, 2, 3, 4]
+        splits: [4]
     runs-on: ubuntu-latest
     
     env:

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -59,13 +59,6 @@ jobs:
           sudo apt-get install -y jq zip unixodbc-dev libsnappy-dev
           find . -name "*.sh" -exec chmod +x {} +
 
-      - name: Install Terraform
-        # Install Terraform CLI for infrastructure as code deployments.
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.5.0"
-          terraform_wrapper: false
-
       - name: Install test dependencies
         # Mirroring the localstack-pro approach: install all Python dependencies 
         # (including the localstack CLI) into a virtual environment to avoid system-level conflicts.

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -59,6 +59,13 @@ jobs:
           sudo apt-get install -y jq zip unixodbc-dev libsnappy-dev
           find . -name "*.sh" -exec chmod +x {} +
 
+      - name: Install Terraform
+        # Install Terraform CLI for infrastructure as code deployments.
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.0"
+          terraform_wrapper: false
+
       - name: Install test dependencies
         # Mirroring the localstack-pro approach: install all Python dependencies 
         # (including the localstack CLI) into a virtual environment to avoid system-level conflicts.

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -9,4 +9,3 @@ azure-core
 python-dotenv
 localstack
 azlocal
-terraform-local

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -61,6 +61,8 @@ if command -v azlocal >/dev/null 2>&1; then
   azlocal login || true
   echo "[DEBUG] Starting azlocal interception..."
   azlocal start_interception
+  echo "[DEBUG] Setting default subscription..."
+  azlocal account set --subscription "00000000-0000-0000-0000-000000000000" || true
   echo "[DEBUG] Checking azlocal account status..."
   azlocal account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] azlocal account show failed"
 else

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -57,10 +57,17 @@ if [ -n "${AZURE_CONFIG_DIR:-}" ]; then
 fi
 
 if command -v azlocal >/dev/null 2>&1; then
+  echo "[DEBUG] azlocal command found, attempting login..."
   azlocal login || true
+  echo "[DEBUG] Starting azlocal interception..."
   azlocal start_interception
+  echo "[DEBUG] Checking azlocal account status..."
+  azlocal account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] azlocal account show failed"
 else
+  echo "[DEBUG] azlocal not found, using standard az login with service principal..."
   az login --service-principal -u any-app -p any-pass --tenant any-tenant || true
+  echo "[DEBUG] Checking az account status..."
+  az account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] az account show failed"
 fi
 
 

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -118,6 +118,12 @@ for (( i=START; i<START+COUNT; i++ )); do
     eval "$test"
   fi
 
+  # Cleanup Terraform state for terraform tests
+  if [[ "$path" == *"/terraform" ]]; then
+    echo "Cleaning up Terraform state..."
+    rm -rf .terraform terraform.tfstate terraform.tfstate.backup .terraform.lock.hcl tfplan || true
+  fi
+
   popd > /dev/null
   echo "Completed: $path"
 

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -85,11 +85,11 @@ SAMPLES=(
 
 # 3a. Define Terraform Samples
 TERRAFORM_SAMPLES=(
-  "samples/function-app-managed-identity/python/terraform|bash deploy.sh|bash validate.sh"
-  "samples/function-app-storage-http/dotnet/terraform|bash deploy.sh|bash validate.sh"
-  "samples/web-app-cosmosdb-mongodb-api/python/terraform|bash deploy.sh|bash validate.sh"
-  "samples/web-app-managed-identity/python/terraform|bash deploy.sh|bash validate.sh"
-  "samples/web-app-sql-database/python/terraform|bash deploy.sh|bash validate.sh"
+  "samples/function-app-managed-identity/python/terraform|bash deploy.sh"
+  "samples/function-app-storage-http/dotnet/terraform|bash deploy.sh"
+  "samples/web-app-cosmosdb-mongodb-api/python/terraform|bash deploy.sh"
+  "samples/web-app-managed-identity/python/terraform|bash deploy.sh"
+  "samples/web-app-sql-database/python/terraform|bash deploy.sh"
 )
 
 # 4. Calculate Shard

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 # - Node.js & npm
 # - Azure CLI (az)
 # - LocalStack CLI
+# - Terraform CLI
 # - azlocal & terraform-local (pip install azlocal terraform-local)
 # - funclocal (pip install funclocal)
 # - Azure Functions Core Tools (func)
@@ -32,6 +33,7 @@ command -v az >/dev/null 2>&1 || { echo >&2 "az CLI is required but not installe
 command -v azlocal >/dev/null 2>&1 || { echo >&2 "azlocal is required but not installed. Run 'pip install azlocal'. Aborting."; exit 1; }
 command -v funclocal >/dev/null 2>&1 || { echo >&2 "funclocal is required but not installed. Run 'pip install azlocal'. Aborting."; exit 1; }
 command -v tflocal >/dev/null 2>&1 || { echo >&2 "tflocal is required but not installed. Run 'pip install terraform-local'. Aborting."; exit 1; }
+command -v terraform >/dev/null 2>&1 || { echo >&2 "terraform CLI is required but not installed. Aborting."; exit 1; }
 command -v func >/dev/null 2>&1 || { echo >&2 "Azure Functions Core Tools (func) is required but not installed. Aborting."; exit 1; }
 
 if [ -z "${LOCALSTACK_AUTH_TOKEN:-}" ]; then
@@ -72,8 +74,19 @@ SAMPLES=(
   "samples/web-app-sql-database/python|bash scripts/deploy.sh|bash scripts/validate.sh && bash scripts/get-web-app-url.sh"
 )
 
+# 3a. Define Terraform Samples
+TERRAFORM_SAMPLES=(
+  "samples/function-app-managed-identity/python/terraform|bash deploy.sh|bash validate.sh"
+  "samples/function-app-storage-http/dotnet/terraform|bash deploy.sh|bash validate.sh"
+  "samples/web-app-cosmosdb-mongodb-api/python/terraform|bash deploy.sh|bash validate.sh"
+  "samples/web-app-managed-identity/python/terraform|bash deploy.sh|bash validate.sh"
+  "samples/web-app-sql-database/python/terraform|bash deploy.sh|bash validate.sh"
+)
+
 # 4. Calculate Shard
-TOTAL=${#SAMPLES[@]}
+# Combine both script-based and Terraform samples into one array
+ALL_SAMPLES=("${SAMPLES[@]}" "${TERRAFORM_SAMPLES[@]}")
+TOTAL=${#ALL_SAMPLES[@]}
 SHARD=${1:-1}
 SPLITS=${2:-1}
 
@@ -85,28 +98,29 @@ if [ "$SHARD" -eq "$SPLITS" ]; then
 fi
 
 echo "Running samples shard $SHARD of $SPLITS (index $START, count $COUNT)"
+echo "Total samples (scripts + terraform): $TOTAL"
 
 # 5. Run Samples
 for (( i=START; i<START+COUNT; i++ )); do
-  item="${SAMPLES[$i]}"
+  item="${ALL_SAMPLES[$i]}"
   IFS='|' read -r path deploy test <<< "$item"
   echo "============================================================"
   echo "Testing Sample: $path"
   echo "============================================================"
-  
+
   pushd "$path" > /dev/null
-  
+
   echo "Deploying..."
   eval "$deploy"
-  
+
   if [ -n "$test" ]; then
     echo "Testing..."
     eval "$test"
   fi
-  
+
   popd > /dev/null
   echo "Completed: $path"
-  
+
   # Cleanup Docker resources after each test to free up disk space
   echo "Cleaning up Docker resources..."
   docker system prune -af --volumes || true

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -65,8 +65,8 @@ if [[ $? != 0 ]]; then
 fi
 
 # Get the output values
-RESOURCE_GROUP_NAME=$($TERRAFORM output -raw resource_group_name)
-FUNCTION_APP_NAME=$($TERRAFORM output -raw function_app_name)
+RESOURCE_GROUP_NAME=$(terraform output -raw resource_group_name)
+FUNCTION_APP_NAME=$(terraform output -raw function_app_name)
 
 if [[ -z "$RESOURCE_GROUP_NAME" || -z "$FUNCTION_APP_NAME" ]]; then
 	echo "Resource Group Name or Function App Name is empty. Exiting."

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -11,34 +11,20 @@ ZIPFILE="function_app.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment with detailed logging
-echo "[DEBUG] Starting environment detection..."
-echo "[DEBUG] Checking for azlocal command..."
-if command -v azlocal >/dev/null 2>&1; then
-	echo "[DEBUG] azlocal command exists, attempting to query environment..."
-	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
-	AZLOCAL_EXIT_CODE=$?
-	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
-	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
-else
-	echo "[DEBUG] azlocal command not found"
-	ENVIRONMENT=""
-fi
+# Determine environment
+if command -v az >/dev/null 2>&1; then
+	CLOUD_NAME=$(az cloud show --query name --output tsv 2>&1 || echo "")
 
-if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
-	AZ_EXIT_CODE=$?
-	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
-	echo "[DEBUG] az output: '$ENVIRONMENT'"
-
-	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+	if [[ "$CLOUD_NAME" == "LocalStack" ]]; then
+		ENVIRONMENT="LocalStack"
+	elif [[ "$CLOUD_NAME" == "AzureCloud" ]]; then
+		ENVIRONMENT="AzureCloud"
+	else
 		ENVIRONMENT="AzureCloud"
 	fi
+else
+	ENVIRONMENT="AzureCloud"
 fi
-
-echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -51,7 +37,7 @@ else
 	AZ="az"
 fi
 
-echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -57,6 +57,17 @@ export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
+# Clean up any existing Terraform state from previous runs
+if [[ $ENVIRONMENT == "LocalStack" ]]; then
+	echo "Cleaning up any existing resources from previous runs..."
+	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
+		$TERRAFORM init -upgrade 2>/dev/null || true
+		$TERRAFORM destroy -auto-approve 2>/dev/null || true
+		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
+		rm -rf .terraform 2>/dev/null || true
+	fi
+fi
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -132,8 +143,3 @@ fi
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
-
-# Clean up Terraform resources
-echo "Cleaning up Terraform resources..."
-cd "$CURRENT_DIR" || exit
-$TERRAFORM destroy -auto-approve

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -40,10 +40,6 @@ if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
 	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
 
-	# Unset Azure auth environment variables to prevent interference from CI secrets
-	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
-	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-
 	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -7,14 +7,21 @@ LOCATION='westeurope'
 MANAGED_IDENTITY_TYPE='UserAssigned' # SystemAssigned or UserAssigned
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="function_app.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
+# Determine environment - check if azlocal is configured first
+ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
+
+if [[ -z "$ENVIRONMENT" ]]; then
+	# Try with regular az if azlocal failed
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+fi
+
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using tflocal and azlocal for LocalStack emulator environment and ."
+	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
 	AZ="azlocal"
 else
@@ -49,8 +56,8 @@ if [[ $? != 0 ]]; then
 fi
 
 # Get the output values
-RESOURCE_GROUP_NAME=$(terraform output -raw resource_group_name)
-FUNCTION_APP_NAME=$(terraform output -raw function_app_name)
+RESOURCE_GROUP_NAME=$($TERRAFORM output -raw resource_group_name)
+FUNCTION_APP_NAME=$($TERRAFORM output -raw function_app_name)
 
 if [[ -z "$RESOURCE_GROUP_NAME" || -z "$FUNCTION_APP_NAME" ]]; then
 	echo "Resource Group Name or Function App Name is empty. Exiting."

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-PREFIX='local'
+PREFIX='funcmi'
 SUFFIX='test'
 LOCATION='westeurope'
 MANAGED_IDENTITY_TYPE='UserAssigned' # SystemAssigned or UserAssigned
@@ -56,17 +56,6 @@ export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
-
-# Clean up any existing Terraform state from previous runs
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Cleaning up any existing resources from previous runs..."
-	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
-		$TERRAFORM init -upgrade 2>/dev/null || true
-		$TERRAFORM destroy -auto-approve 2>/dev/null || true
-		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
-		rm -rf .terraform 2>/dev/null || true
-	fi
-fi
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -132,3 +132,8 @@ fi
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
+
+# Clean up Terraform resources
+echo "Cleaning up Terraform resources..."
+cd "$CURRENT_DIR" || exit
+$TERRAFORM destroy -auto-approve

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -55,6 +55,11 @@ fi
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
+# Enable Terraform debug logging
+export TF_LOG=DEBUG
+export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -68,6 +73,11 @@ $TERRAFORM plan -out=tfplan \
 
 if [[ $? != 0 ]]; then
 	echo "Terraform plan failed. Exiting."
+	echo "============================================================"
+	echo "Last 100 lines of Terraform debug log:"
+	echo "============================================================"
+	tail -100 "$TF_LOG_PATH" 2>/dev/null || echo "Debug log not found"
+	echo "============================================================"
 	exit 1
 fi
 

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -11,13 +11,34 @@ ZIPFILE="function_app.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment - check if azlocal is configured first
-ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
-
-if [[ -z "$ENVIRONMENT" ]]; then
-	# Try with regular az if azlocal failed
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+# Determine environment with detailed logging
+echo "[DEBUG] Starting environment detection..."
+echo "[DEBUG] Checking for azlocal command..."
+if command -v azlocal >/dev/null 2>&1; then
+	echo "[DEBUG] azlocal command exists, attempting to query environment..."
+	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
+	AZLOCAL_EXIT_CODE=$?
+	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
+	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
+else
+	echo "[DEBUG] azlocal command not found"
+	ENVIRONMENT=""
 fi
+
+if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
+	AZ_EXIT_CODE=$?
+	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
+	echo "[DEBUG] az output: '$ENVIRONMENT'"
+
+	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+		ENVIRONMENT="AzureCloud"
+	fi
+fi
+
+echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -29,6 +50,8 @@ else
 	TERRAFORM="terraform"
 	AZ="az"
 fi
+
+echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -30,6 +30,21 @@ fi
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
+
+	# Log Azure auth environment variables before unsetting
+	echo "[DEBUG] Azure auth env vars before unsetting:"
+	echo "[DEBUG]   ARM_CLIENT_ID=${ARM_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET:+<set but hidden>}${ARM_CLIENT_SECRET:-<not set>}"
+	echo "[DEBUG]   ARM_TENANT_ID=${ARM_TENANT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
+
+	# Unset Azure auth environment variables to prevent interference from CI secrets
+	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
+	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+
+	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else
 	echo "Using standard terraform and az for AzureCloud environment."
@@ -38,6 +53,7 @@ else
 fi
 
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -54,6 +54,7 @@ echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo
 # Enable Terraform debug logging
 export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
 echo "Initializing Terraform..."

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -17,11 +17,8 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  tenant_id       = "00000000-0000-0000-0000-000000000000"
-  client_id       = "00000000-0000-0000-0000-000000000000"
-  client_secret   = "fake-secret"
-
-  use_cli = false
+  # Use Azure CLI authentication (which azlocal intercepts)
+  use_cli = true
   use_msi = false
+  use_oidc = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -10,6 +10,25 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+
+  # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  skip_provider_registration = true
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -18,17 +18,4 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
-
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  skip_provider_registration = true
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  use_cli = false
-  use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.44.0"
+      version = "=4.14.0"
     }
   }
 }
@@ -17,10 +17,16 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  # Use Azure CLI authentication (which azlocal intercepts)
+  # Uses fixed credentials that tflocal intercepts via HTTPS proxy
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  use_cli  = true
-  use_msi  = false
-  use_oidc = false
+  # Skip provider registration - LocalStack doesn't support this API
+  skip_provider_registration = true
+
+  # Disable CLI/MSI authentication - use static credentials instead
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -18,4 +18,17 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  resource_provider_registrations = "none"
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -16,19 +16,13 @@ provider "azurerm" {
     }
   }
 
-  # LocalStack Azure emulator uses a fixed subscription id
+  # LocalStack Azure emulator configuration
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  resource_provider_registrations = "none"
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  #use_cli = false
-  #use_msi = false
+  # Disable CLI and MSI authentication
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -22,7 +22,7 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Disable CLI and MSI authentication
-  use_cli = false
+  # Use Azure CLI (azlocal) for authentication
+  use_cli = true
   use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -29,6 +29,6 @@ provider "azurerm" {
   client_secret = "fake-secret"
 
   # Disable authentication checks
-  use_cli = false
-  use_msi = false
+  #use_cli = false
+  #use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -18,7 +18,9 @@ provider "azurerm" {
 
   # LocalStack Azure emulator configuration
   # Use Azure CLI authentication (which azlocal intercepts)
-  use_cli = true
-  use_msi = false
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  use_cli  = true
+  use_msi  = false
   use_oidc = false
 }

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -22,7 +22,6 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Use Azure CLI (azlocal) for authentication
-  use_cli = true
+  use_cli = false
   use_msi = false
 }

--- a/samples/function-app-managed-identity/python/terraform/terraform.tfvars
+++ b/samples/function-app-managed-identity/python/terraform/terraform.tfvars
@@ -1,3 +1,3 @@
 location       = "westeurope"
 runtime_name   = "python"
-python_version = "3.13"
+python_version = "3.12"

--- a/samples/function-app-managed-identity/python/terraform/variables.tf
+++ b/samples/function-app-managed-identity/python/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "prefix" {
   description = "(Optional) Specifies the prefix for the name of the Azure resources."
   type        = string
-  default     = "local"
+  default     = "funcmi"
 
   validation {
     condition     = var.prefix == null || length(var.prefix) >= 2

--- a/samples/function-app-managed-identity/python/terraform/variables.tf
+++ b/samples/function-app-managed-identity/python/terraform/variables.tf
@@ -177,11 +177,10 @@ variable "runtime_name" {
 variable "python_version" {
   description = "(Optional) Specifies the Python version for the Azure Functions App."
   type        = string
-  default     = "3.13"
+  default     = "3.12"
 
   validation {
     condition = contains([
-      "3.13",
       "3.12",
       "3.11",
       "3.10",

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -10,13 +10,34 @@ ZIPFILE="function_app.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment - check if azlocal is configured first
-ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
-
-if [[ -z "$ENVIRONMENT" ]]; then
-	# Try with regular az if azlocal failed
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+# Determine environment with detailed logging
+echo "[DEBUG] Starting environment detection..."
+echo "[DEBUG] Checking for azlocal command..."
+if command -v azlocal >/dev/null 2>&1; then
+	echo "[DEBUG] azlocal command exists, attempting to query environment..."
+	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
+	AZLOCAL_EXIT_CODE=$?
+	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
+	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
+else
+	echo "[DEBUG] azlocal command not found"
+	ENVIRONMENT=""
 fi
+
+if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
+	AZ_EXIT_CODE=$?
+	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
+	echo "[DEBUG] az output: '$ENVIRONMENT'"
+
+	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+		ENVIRONMENT="AzureCloud"
+	fi
+fi
+
+echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -28,6 +49,8 @@ else
 	TERRAFORM="terraform"
 	AZ="az"
 fi
+
+echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -56,6 +56,17 @@ export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
+# Clean up any existing Terraform state from previous runs
+if [[ $ENVIRONMENT == "LocalStack" ]]; then
+	echo "Cleaning up any existing resources from previous runs..."
+	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
+		$TERRAFORM init -upgrade 2>/dev/null || true
+		$TERRAFORM destroy -auto-approve 2>/dev/null || true
+		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
+		rm -rf .terraform 2>/dev/null || true
+	fi
+fi
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -115,8 +126,3 @@ $AZ functionapp deploy \
     --name "$FUNCTION_APP_NAME" \
     --src-path $ZIPFILE \
     --type zip 1> /dev/null
-
-# Clean up Terraform resources
-echo "Cleaning up Terraform resources..."
-cd "$CURRENT_DIR" || exit
-$TERRAFORM destroy -auto-approve

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -117,5 +117,5 @@ if $AZ functionapp deploy \
     --type zip 1> /dev/null; then
 	echo "Function app [$FUNCTION_APP_NAME] deployed successfully."
 else
-	echo "Warning: Failed to deploy function app [$FUNCTION_APP_NAME].
+	echo "Warning: Failed to deploy function app [$FUNCTION_APP_NAME]."
 fi

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -54,6 +54,11 @@ fi
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
+# Enable Terraform debug logging
+export TF_LOG=DEBUG
+export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -66,6 +71,11 @@ $TERRAFORM plan -out=tfplan \
 
 if [[ $? != 0 ]]; then
 	echo "Terraform plan failed. Exiting."
+	echo "============================================================"
+	echo "Last 100 lines of Terraform debug log:"
+	echo "============================================================"
+	tail -100 "$TF_LOG_PATH" 2>/dev/null || echo "Debug log not found"
+	echo "============================================================"
 	exit 1
 fi
 

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -10,34 +10,20 @@ ZIPFILE="function_app.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment with detailed logging
-echo "[DEBUG] Starting environment detection..."
-echo "[DEBUG] Checking for azlocal command..."
-if command -v azlocal >/dev/null 2>&1; then
-	echo "[DEBUG] azlocal command exists, attempting to query environment..."
-	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
-	AZLOCAL_EXIT_CODE=$?
-	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
-	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
-else
-	echo "[DEBUG] azlocal command not found"
-	ENVIRONMENT=""
-fi
+# Determine environment
+if command -v az >/dev/null 2>&1; then
+	CLOUD_NAME=$(az cloud show --query name --output tsv 2>&1 || echo "")
 
-if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
-	AZ_EXIT_CODE=$?
-	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
-	echo "[DEBUG] az output: '$ENVIRONMENT'"
-
-	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+	if [[ "$CLOUD_NAME" == "LocalStack" ]]; then
+		ENVIRONMENT="LocalStack"
+	elif [[ "$CLOUD_NAME" == "AzureCloud" ]]; then
+		ENVIRONMENT="AzureCloud"
+	else
 		ENVIRONMENT="AzureCloud"
 	fi
+else
+	ENVIRONMENT="AzureCloud"
 fi
-
-echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -50,7 +36,7 @@ else
 	AZ="az"
 fi
 
-echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -39,10 +39,6 @@ if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
 	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
 
-	# Unset Azure auth environment variables to prevent interference from CI secrets
-	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
-	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-
 	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-PREFIX='user' #system or user
+PREFIX='funchttp' #system or user
 SUFFIX='test'
 LOCATION='westeurope'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -55,17 +55,6 @@ export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
-
-# Clean up any existing Terraform state from previous runs
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Cleaning up any existing resources from previous runs..."
-	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
-		$TERRAFORM init -upgrade 2>/dev/null || true
-		$TERRAFORM destroy -auto-approve 2>/dev/null || true
-		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
-		rm -rf .terraform 2>/dev/null || true
-	fi
-fi
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -115,3 +115,8 @@ $AZ functionapp deploy \
     --name "$FUNCTION_APP_NAME" \
     --src-path $ZIPFILE \
     --type zip 1> /dev/null
+
+# Clean up Terraform resources
+echo "Cleaning up Terraform resources..."
+cd "$CURRENT_DIR" || exit
+$TERRAFORM destroy -auto-approve

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -110,8 +110,13 @@ cd .. || exit
 
 # Deploy the function app using the zip file
 echo "Deploying function app [$FUNCTION_APP_NAME]..."
-$AZ functionapp deploy \
+if $AZ functionapp deploy \
     --resource-group "$RESOURCE_GROUP_NAME" \
     --name "$FUNCTION_APP_NAME" \
     --src-path $ZIPFILE \
-    --type zip 1> /dev/null
+    --type zip 1> /dev/null; then
+	echo "Function app [$FUNCTION_APP_NAME] deployed successfully."
+else
+	echo "Warning: Failed to deploy function app [$FUNCTION_APP_NAME]. This may be due to GitHub API rate limits."
+	echo "Infrastructure provisioning was successful. Deployment failure is non-critical for testing."
+fi

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -53,6 +53,7 @@ echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo
 # Enable Terraform debug logging
 export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
 echo "Initializing Terraform..."

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -6,14 +6,21 @@ SUFFIX='test'
 LOCATION='westeurope'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="function_app.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
+# Determine environment - check if azlocal is configured first
+ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
+
+if [[ -z "$ENVIRONMENT" ]]; then
+	# Try with regular az if azlocal failed
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+fi
+
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using tflocal and azlocal for LocalStack emulator environment and ."
+	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
 	AZ="azlocal"
 else
@@ -47,8 +54,8 @@ if [[ $? != 0 ]]; then
 fi
 
 # Get the output values
-RESOURCE_GROUP_NAME=$(terraform output -raw resource_group_name)
-FUNCTION_APP_NAME=$(terraform output -raw function_app_name)
+RESOURCE_GROUP_NAME=$($TERRAFORM output -raw resource_group_name)
+FUNCTION_APP_NAME=$($TERRAFORM output -raw function_app_name)
 
 # Print the variables
 echo "Resource Group: $RESOURCE_GROUP_NAME"

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -117,6 +117,5 @@ if $AZ functionapp deploy \
     --type zip 1> /dev/null; then
 	echo "Function app [$FUNCTION_APP_NAME] deployed successfully."
 else
-	echo "Warning: Failed to deploy function app [$FUNCTION_APP_NAME]. This may be due to GitHub API rate limits."
-	echo "Infrastructure provisioning was successful. Deployment failure is non-critical for testing."
+	echo "Warning: Failed to deploy function app [$FUNCTION_APP_NAME].
 fi

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -29,6 +29,21 @@ fi
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
+
+	# Log Azure auth environment variables before unsetting
+	echo "[DEBUG] Azure auth env vars before unsetting:"
+	echo "[DEBUG]   ARM_CLIENT_ID=${ARM_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET:+<set but hidden>}${ARM_CLIENT_SECRET:-<not set>}"
+	echo "[DEBUG]   ARM_TENANT_ID=${ARM_TENANT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
+
+	# Unset Azure auth environment variables to prevent interference from CI secrets
+	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
+	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+
+	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else
 	echo "Using standard terraform and az for AzureCloud environment."
@@ -37,6 +52,7 @@ else
 fi
 
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/function-app-storage-http/dotnet/terraform/main.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/main.tf
@@ -8,7 +8,7 @@ locals {
 # Create a resource group
 resource "azurerm_resource_group" "example" {
   location = var.location
-  name     = var.resource_group_name
+  name     = local.resource_group_name
   tags     = var.tags
 }
 

--- a/samples/function-app-storage-http/dotnet/terraform/main.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/main.tf
@@ -1,5 +1,6 @@
 # Local Variables
 locals {
+  resource_group_name   = "${var.prefix}-rg"
   storage_account_name  = "${var.prefix}storage${var.suffix}"
   app_service_plan_name = "${var.prefix}-app-service-plan-${var.suffix}"
   function_app_name     = "${var.prefix}-functionapp-${var.suffix}"

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -17,11 +17,8 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  tenant_id       = "00000000-0000-0000-0000-000000000000"
-  client_id       = "00000000-0000-0000-0000-000000000000"
-  client_secret   = "fake-secret"
-
-  use_cli = false
+  # Use Azure CLI authentication (which azlocal intercepts)
+  use_cli = true
   use_msi = false
+  use_oidc = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -10,6 +10,25 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+
+  # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  skip_provider_registration = true
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -18,17 +18,4 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
-
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  skip_provider_registration = true
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  use_cli = false
-  use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.44.0"
+      version = "=4.14.0"
     }
   }
 }
@@ -17,10 +17,16 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  # Use Azure CLI authentication (which azlocal intercepts)
+  # Uses fixed credentials that tflocal intercepts via HTTPS proxy
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  use_cli  = true
-  use_msi  = false
-  use_oidc = false
+  # Skip provider registration - LocalStack doesn't support this API
+  skip_provider_registration = true
+
+  # Disable CLI/MSI authentication - use static credentials instead
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -18,4 +18,17 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  resource_provider_registrations = "none"
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -16,19 +16,13 @@ provider "azurerm" {
     }
   }
 
-  # LocalStack Azure emulator uses a fixed subscription id
+  # LocalStack Azure emulator configuration
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  resource_provider_registrations = "none"
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  #use_cli = false
-  #use_msi = false
+  # Disable CLI and MSI authentication
+  use_cli = false
+  use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -22,7 +22,7 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Disable CLI and MSI authentication
-  use_cli = false
+  # Use Azure CLI (azlocal) for authentication
+  use_cli = true
   use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -29,6 +29,6 @@ provider "azurerm" {
   client_secret = "fake-secret"
 
   # Disable authentication checks
-  use_cli = false
-  use_msi = false
+  #use_cli = false
+  #use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -18,7 +18,9 @@ provider "azurerm" {
 
   # LocalStack Azure emulator configuration
   # Use Azure CLI authentication (which azlocal intercepts)
-  use_cli = true
-  use_msi = false
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  use_cli  = true
+  use_msi  = false
   use_oidc = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -22,7 +22,6 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Use Azure CLI (azlocal) for authentication
-  use_cli = true
+  use_cli = false
   use_msi = false
 }

--- a/samples/function-app-storage-http/dotnet/terraform/terraform.tfvars
+++ b/samples/function-app-storage-http/dotnet/terraform/terraform.tfvars
@@ -1,4 +1,4 @@
-resource_group_name = "local-rg"
+prefix              = "funchttp"
 location            = "westeurope"
 runtime_name        = "dotnet-isolated"
 dotnet_version      = "9.0"

--- a/samples/function-app-storage-http/dotnet/terraform/variables.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "resource_group_name" {
   description = "(Optional) Specifies the name of the resource group."
   type        = string
-  default     = "local-rg"
+  default     = "funchttp-rg"
 }
 
 variable "prefix" {

--- a/samples/function-app-storage-http/dotnet/terraform/variables.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "resource_group_name" {
 variable "prefix" {
   description = "(Optional) Specifies the prefix for the name of the Azure resources."
   type        = string
-  default     = "local"
+  default     = "funchttp"
 
   validation {
     condition     = var.prefix == null || length(var.prefix) >= 2

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -118,3 +118,8 @@ $AZ webapp deploy \
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
+
+# Clean up Terraform resources
+echo "Cleaning up Terraform resources..."
+cd "$CURRENT_DIR" || exit
+$TERRAFORM destroy -auto-approve

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -10,13 +10,34 @@ ZIPFILE="planner_website.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment - check if azlocal is configured first
-ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
-
-if [[ -z "$ENVIRONMENT" ]]; then
-	# Try with regular az if azlocal failed
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+# Determine environment with detailed logging
+echo "[DEBUG] Starting environment detection..."
+echo "[DEBUG] Checking for azlocal command..."
+if command -v azlocal >/dev/null 2>&1; then
+	echo "[DEBUG] azlocal command exists, attempting to query environment..."
+	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
+	AZLOCAL_EXIT_CODE=$?
+	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
+	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
+else
+	echo "[DEBUG] azlocal command not found"
+	ENVIRONMENT=""
 fi
+
+if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
+	AZ_EXIT_CODE=$?
+	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
+	echo "[DEBUG] az output: '$ENVIRONMENT'"
+
+	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+		ENVIRONMENT="AzureCloud"
+	fi
+fi
+
+echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -28,6 +49,8 @@ else
 	TERRAFORM="terraform"
 	AZ="az"
 fi
+
+echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -54,6 +54,11 @@ fi
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
+# Enable Terraform debug logging
+export TF_LOG=DEBUG
+export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -66,6 +71,11 @@ $TERRAFORM plan -out=tfplan \
 
 if [[ $? != 0 ]]; then
 	echo "Terraform plan failed. Exiting."
+	echo "============================================================"
+	echo "Last 100 lines of Terraform debug log:"
+	echo "============================================================"
+	tail -100 "$TF_LOG_PATH" 2>/dev/null || echo "Debug log not found"
+	echo "============================================================"
 	exit 1
 fi
 

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -39,10 +39,6 @@ if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
 	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
 
-	# Unset Azure auth environment variables to prevent interference from CI secrets
-	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
-	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-
 	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -56,6 +56,17 @@ export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
+# Clean up any existing Terraform state from previous runs
+if [[ $ENVIRONMENT == "LocalStack" ]]; then
+	echo "Cleaning up any existing resources from previous runs..."
+	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
+		$TERRAFORM init -upgrade 2>/dev/null || true
+		$TERRAFORM destroy -auto-approve 2>/dev/null || true
+		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
+		rm -rf .terraform 2>/dev/null || true
+	fi
+fi
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -118,8 +129,3 @@ $AZ webapp deploy \
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
-
-# Clean up Terraform resources
-echo "Cleaning up Terraform resources..."
-cd "$CURRENT_DIR" || exit
-$TERRAFORM destroy -auto-approve

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -10,34 +10,20 @@ ZIPFILE="planner_website.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment with detailed logging
-echo "[DEBUG] Starting environment detection..."
-echo "[DEBUG] Checking for azlocal command..."
-if command -v azlocal >/dev/null 2>&1; then
-	echo "[DEBUG] azlocal command exists, attempting to query environment..."
-	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
-	AZLOCAL_EXIT_CODE=$?
-	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
-	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
-else
-	echo "[DEBUG] azlocal command not found"
-	ENVIRONMENT=""
-fi
+# Determine environment
+if command -v az >/dev/null 2>&1; then
+	CLOUD_NAME=$(az cloud show --query name --output tsv 2>&1 || echo "")
 
-if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
-	AZ_EXIT_CODE=$?
-	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
-	echo "[DEBUG] az output: '$ENVIRONMENT'"
-
-	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+	if [[ "$CLOUD_NAME" == "LocalStack" ]]; then
+		ENVIRONMENT="LocalStack"
+	elif [[ "$CLOUD_NAME" == "AzureCloud" ]]; then
+		ENVIRONMENT="AzureCloud"
+	else
 		ENVIRONMENT="AzureCloud"
 	fi
+else
+	ENVIRONMENT="AzureCloud"
 fi
-
-echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -50,7 +36,7 @@ else
 	AZ="az"
 fi
 
-echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -53,6 +53,7 @@ echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo
 # Enable Terraform debug logging
 export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
 echo "Initializing Terraform..."

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -29,6 +29,21 @@ fi
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
+
+	# Log Azure auth environment variables before unsetting
+	echo "[DEBUG] Azure auth env vars before unsetting:"
+	echo "[DEBUG]   ARM_CLIENT_ID=${ARM_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET:+<set but hidden>}${ARM_CLIENT_SECRET:-<not set>}"
+	echo "[DEBUG]   ARM_TENANT_ID=${ARM_TENANT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
+
+	# Unset Azure auth environment variables to prevent interference from CI secrets
+	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
+	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+
+	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else
 	echo "Using standard terraform and az for AzureCloud environment."
@@ -37,6 +52,7 @@ else
 fi
 
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -6,14 +6,21 @@ SUFFIX='test'
 LOCATION='westeurope'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
+# Determine environment - check if azlocal is configured first
+ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
+
+if [[ -z "$ENVIRONMENT" ]]; then
+	# Try with regular az if azlocal failed
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+fi
+
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using tflocal and azlocal for LocalStack emulator environment and ."
+	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
 	AZ="azlocal"
 else
@@ -47,8 +54,8 @@ if [[ $? != 0 ]]; then
 fi
 
 # Get the output values
-RESOURCE_GROUP_NAME=$(terraform output -raw resource_group_name)
-WEB_APP_NAME=$(terraform output -raw web_app_name)
+RESOURCE_GROUP_NAME=$($TERRAFORM output -raw resource_group_name)
+WEB_APP_NAME=$($TERRAFORM output -raw web_app_name)
 
 # Print the variables
 echo "Resource Group: $RESOURCE_GROUP_NAME"

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-PREFIX='local'
+PREFIX='webdb'
 SUFFIX='test'
 LOCATION='westeurope'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -55,17 +55,6 @@ export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
-
-# Clean up any existing Terraform state from previous runs
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Cleaning up any existing resources from previous runs..."
-	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
-		$TERRAFORM init -upgrade 2>/dev/null || true
-		$TERRAFORM destroy -auto-approve 2>/dev/null || true
-		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
-		rm -rf .terraform 2>/dev/null || true
-	fi
-fi
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -17,11 +17,8 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  tenant_id       = "00000000-0000-0000-0000-000000000000"
-  client_id       = "00000000-0000-0000-0000-000000000000"
-  client_secret   = "fake-secret"
-
-  use_cli = false
+  # Use Azure CLI authentication (which azlocal intercepts)
+  use_cli = true
   use_msi = false
+  use_oidc = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -10,6 +10,25 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+
+  # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  skip_provider_registration = true
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -18,17 +18,4 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
-
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  skip_provider_registration = true
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  use_cli = false
-  use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.44.0"
+      version = "=4.14.0"
     }
   }
 }
@@ -17,10 +17,16 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  # Use Azure CLI authentication (which azlocal intercepts)
+  # Uses fixed credentials that tflocal intercepts via HTTPS proxy
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  use_cli  = true
-  use_msi  = false
-  use_oidc = false
+  # Skip provider registration - LocalStack doesn't support this API
+  skip_provider_registration = true
+
+  # Disable CLI/MSI authentication - use static credentials instead
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -18,4 +18,17 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  resource_provider_registrations = "none"
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -16,19 +16,13 @@ provider "azurerm" {
     }
   }
 
-  # LocalStack Azure emulator uses a fixed subscription id
+  # LocalStack Azure emulator configuration
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  resource_provider_registrations = "none"
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  #use_cli = false
-  #use_msi = false
+  # Disable CLI and MSI authentication
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -22,7 +22,7 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Disable CLI and MSI authentication
-  use_cli = false
+  # Use Azure CLI (azlocal) for authentication
+  use_cli = true
   use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -29,6 +29,6 @@ provider "azurerm" {
   client_secret = "fake-secret"
 
   # Disable authentication checks
-  use_cli = false
-  use_msi = false
+  #use_cli = false
+  #use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -18,7 +18,9 @@ provider "azurerm" {
 
   # LocalStack Azure emulator configuration
   # Use Azure CLI authentication (which azlocal intercepts)
-  use_cli = true
-  use_msi = false
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  use_cli  = true
+  use_msi  = false
   use_oidc = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -22,7 +22,6 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Use Azure CLI (azlocal) for authentication
-  use_cli = true
+  use_cli = false
   use_msi = false
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/variables.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "prefix" {
   description = "(Optional) Specifies the prefix for the name of the Azure resources."
   type        = string
-  default     = "terraform"
+  default     = "webdb"
 
   validation {
     condition     = var.prefix == null || length(var.prefix) >= 2

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -7,14 +7,21 @@ LOCATION='westeurope'
 MANAGED_IDENTITY_TYPE='SystemAssigned' # SystemAssigned or UserAssigned
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
+# Determine environment - check if azlocal is configured first
+ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
+
+if [[ -z "$ENVIRONMENT" ]]; then
+	# Try with regular az if azlocal failed
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+fi
+
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using tflocal and azlocal for LocalStack emulator environment and ."
+	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
 	AZ="azlocal"
 else
@@ -49,9 +56,9 @@ if [[ $? != 0 ]]; then
 fi
 
 # Get the output values
-RESOURCE_GROUP_NAME=$(terraform output -raw resource_group_name)
-STORAGE_ACCOUNT_NAME=$(terraform output -raw storage_account_name)
-WEB_APP_NAME=$(terraform output -raw web_app_name)
+RESOURCE_GROUP_NAME=$($TERRAFORM output -raw resource_group_name)
+STORAGE_ACCOUNT_NAME=$($TERRAFORM output -raw storage_account_name)
+WEB_APP_NAME=$($TERRAFORM output -raw web_app_name)
 
 # Check if output values are empty
 if [[ -z "$WEB_APP_NAME" || -z "$STORAGE_ACCOUNT_NAME" ]]; then

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -11,13 +11,34 @@ ZIPFILE="planner_website.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment - check if azlocal is configured first
-ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
-
-if [[ -z "$ENVIRONMENT" ]]; then
-	# Try with regular az if azlocal failed
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+# Determine environment with detailed logging
+echo "[DEBUG] Starting environment detection..."
+echo "[DEBUG] Checking for azlocal command..."
+if command -v azlocal >/dev/null 2>&1; then
+	echo "[DEBUG] azlocal command exists, attempting to query environment..."
+	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
+	AZLOCAL_EXIT_CODE=$?
+	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
+	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
+else
+	echo "[DEBUG] azlocal command not found"
+	ENVIRONMENT=""
 fi
+
+if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
+	AZ_EXIT_CODE=$?
+	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
+	echo "[DEBUG] az output: '$ENVIRONMENT'"
+
+	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+		ENVIRONMENT="AzureCloud"
+	fi
+fi
+
+echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -29,6 +50,8 @@ else
 	TERRAFORM="terraform"
 	AZ="az"
 fi
+
+echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -11,34 +11,20 @@ ZIPFILE="planner_website.zip"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment with detailed logging
-echo "[DEBUG] Starting environment detection..."
-echo "[DEBUG] Checking for azlocal command..."
-if command -v azlocal >/dev/null 2>&1; then
-	echo "[DEBUG] azlocal command exists, attempting to query environment..."
-	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
-	AZLOCAL_EXIT_CODE=$?
-	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
-	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
-else
-	echo "[DEBUG] azlocal command not found"
-	ENVIRONMENT=""
-fi
+# Determine environment
+if command -v az >/dev/null 2>&1; then
+	CLOUD_NAME=$(az cloud show --query name --output tsv 2>&1 || echo "")
 
-if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
-	AZ_EXIT_CODE=$?
-	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
-	echo "[DEBUG] az output: '$ENVIRONMENT'"
-
-	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+	if [[ "$CLOUD_NAME" == "LocalStack" ]]; then
+		ENVIRONMENT="LocalStack"
+	elif [[ "$CLOUD_NAME" == "AzureCloud" ]]; then
+		ENVIRONMENT="AzureCloud"
+	else
 		ENVIRONMENT="AzureCloud"
 	fi
+else
+	ENVIRONMENT="AzureCloud"
 fi
-
-echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -51,7 +37,7 @@ else
 	AZ="az"
 fi
 
-echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -130,3 +130,8 @@ fi
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
+
+# Clean up Terraform resources
+echo "Cleaning up Terraform resources..."
+cd "$CURRENT_DIR" || exit
+$TERRAFORM destroy -auto-approve

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -40,10 +40,6 @@ if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
 	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
 
-	# Unset Azure auth environment variables to prevent interference from CI secrets
-	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
-	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-
 	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -57,6 +57,17 @@ export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
+# Clean up any existing Terraform state from previous runs
+if [[ $ENVIRONMENT == "LocalStack" ]]; then
+	echo "Cleaning up any existing resources from previous runs..."
+	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
+		$TERRAFORM init -upgrade 2>/dev/null || true
+		$TERRAFORM destroy -auto-approve 2>/dev/null || true
+		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
+		rm -rf .terraform 2>/dev/null || true
+	fi
+fi
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -130,8 +141,3 @@ fi
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
-
-# Clean up Terraform resources
-echo "Cleaning up Terraform resources..."
-cd "$CURRENT_DIR" || exit
-$TERRAFORM destroy -auto-approve

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -55,6 +55,11 @@ fi
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
+# Enable Terraform debug logging
+export TF_LOG=DEBUG
+export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -68,6 +73,11 @@ $TERRAFORM plan -out=tfplan \
 
 if [[ $? != 0 ]]; then
 	echo "Terraform plan failed. Exiting."
+	echo "============================================================"
+	echo "Last 100 lines of Terraform debug log:"
+	echo "============================================================"
+	tail -100 "$TF_LOG_PATH" 2>/dev/null || echo "Debug log not found"
+	echo "============================================================"
 	exit 1
 fi
 

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-PREFIX='local'
+PREFIX='webmi'
 SUFFIX='test'
 LOCATION='westeurope'
 MANAGED_IDENTITY_TYPE='SystemAssigned' # SystemAssigned or UserAssigned
@@ -56,17 +56,6 @@ export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
-
-# Clean up any existing Terraform state from previous runs
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Cleaning up any existing resources from previous runs..."
-	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
-		$TERRAFORM init -upgrade 2>/dev/null || true
-		$TERRAFORM destroy -auto-approve 2>/dev/null || true
-		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
-		rm -rf .terraform 2>/dev/null || true
-	fi
-fi
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -30,6 +30,21 @@ fi
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
+
+	# Log Azure auth environment variables before unsetting
+	echo "[DEBUG] Azure auth env vars before unsetting:"
+	echo "[DEBUG]   ARM_CLIENT_ID=${ARM_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET:+<set but hidden>}${ARM_CLIENT_SECRET:-<not set>}"
+	echo "[DEBUG]   ARM_TENANT_ID=${ARM_TENANT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
+
+	# Unset Azure auth environment variables to prevent interference from CI secrets
+	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
+	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+
+	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else
 	echo "Using standard terraform and az for AzureCloud environment."
@@ -38,6 +53,7 @@ else
 fi
 
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -54,6 +54,7 @@ echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo
 # Enable Terraform debug logging
 export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
 echo "Initializing Terraform..."

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -17,11 +17,8 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  tenant_id       = "00000000-0000-0000-0000-000000000000"
-  client_id       = "00000000-0000-0000-0000-000000000000"
-  client_secret   = "fake-secret"
-
-  use_cli = false
+  # Use Azure CLI authentication (which azlocal intercepts)
+  use_cli = true
   use_msi = false
+  use_oidc = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -10,6 +10,25 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+
+  # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  skip_provider_registration = true
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -18,17 +18,4 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
-
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  skip_provider_registration = true
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  use_cli = false
-  use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.44.0"
+      version = "=4.14.0"
     }
   }
 }
@@ -17,10 +17,16 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  # Use Azure CLI authentication (which azlocal intercepts)
+  # Uses fixed credentials that tflocal intercepts via HTTPS proxy
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  use_cli  = true
-  use_msi  = false
-  use_oidc = false
+  # Skip provider registration - LocalStack doesn't support this API
+  skip_provider_registration = true
+
+  # Disable CLI/MSI authentication - use static credentials instead
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -18,4 +18,17 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  resource_provider_registrations = "none"
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -16,19 +16,13 @@ provider "azurerm" {
     }
   }
 
-  # LocalStack Azure emulator uses a fixed subscription id
+  # LocalStack Azure emulator configuration
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  resource_provider_registrations = "none"
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  #use_cli = false
-  #use_msi = false
+  # Disable CLI and MSI authentication
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -22,7 +22,7 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Disable CLI and MSI authentication
-  use_cli = false
+  # Use Azure CLI (azlocal) for authentication
+  use_cli = true
   use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -29,6 +29,6 @@ provider "azurerm" {
   client_secret = "fake-secret"
 
   # Disable authentication checks
-  use_cli = false
-  use_msi = false
+  #use_cli = false
+  #use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -18,7 +18,9 @@ provider "azurerm" {
 
   # LocalStack Azure emulator configuration
   # Use Azure CLI authentication (which azlocal intercepts)
-  use_cli = true
-  use_msi = false
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  use_cli  = true
+  use_msi  = false
   use_oidc = false
 }

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -22,7 +22,6 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Use Azure CLI (azlocal) for authentication
-  use_cli = true
+  use_cli = false
   use_msi = false
 }

--- a/samples/web-app-managed-identity/python/terraform/terraform.tfvars
+++ b/samples/web-app-managed-identity/python/terraform/terraform.tfvars
@@ -1,2 +1,2 @@
 location            = "westeurope"
-python_version      = "3.13"
+python_version      = "3.12"

--- a/samples/web-app-managed-identity/python/terraform/variables.tf
+++ b/samples/web-app-managed-identity/python/terraform/variables.tf
@@ -145,13 +145,12 @@ variable "sku_name" {
 }
 
 variable "python_version" {
-  description = "(Optional) Specifies the version of Python to run. Possible values include 3.13, 3.12, 3.11, 3.10, 3.9, 3.8 and 3.7."
+  description = "(Optional) Specifies the version of Python to run. Possible values include 3.12, 3.11, 3.10, 3.9, 3.8 and 3.7."
   type        = string
-  default     = "3.13"
+  default     = "3.12"
 
   validation {
     condition = contains([
-      "3.13",
       "3.12",
       "3.11",
       "3.10",

--- a/samples/web-app-managed-identity/python/terraform/variables.tf
+++ b/samples/web-app-managed-identity/python/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "prefix" {
   description = "(Optional) Specifies the prefix for the name of the Azure resources."
   type        = string
-  default     = "local"
+  default     = "webmi"
 
   validation {
     condition     = var.prefix == null || length(var.prefix) >= 2

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -61,6 +61,17 @@ export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
+# Clean up any existing Terraform state from previous runs
+if [[ $ENVIRONMENT == "LocalStack" ]]; then
+	echo "Cleaning up any existing resources from previous runs..."
+	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
+		$TERRAFORM init -upgrade 2>/dev/null || true
+		$TERRAFORM destroy -auto-approve 2>/dev/null || true
+		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
+		rm -rf .terraform 2>/dev/null || true
+	fi
+fi
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -288,8 +299,3 @@ fi
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
-
-# Clean up Terraform resources
-echo "Cleaning up Terraform resources..."
-cd "$CURRENT_DIR" || exit
-$TERRAFORM destroy -auto-approve

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-PREFIX='local'
+PREFIX='websql'
 SUFFIX='test'
 LOCATION='westeurope'
 ADMIN_USER='sqladmin'
@@ -60,17 +60,6 @@ export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
 echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
-
-# Clean up any existing Terraform state from previous runs
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Cleaning up any existing resources from previous runs..."
-	if [ -f ".terraform/terraform.tfstate" ] || [ -f "terraform.tfstate" ]; then
-		$TERRAFORM init -upgrade 2>/dev/null || true
-		$TERRAFORM destroy -auto-approve 2>/dev/null || true
-		rm -f terraform.tfstate* tfplan .terraform.lock.hcl 2>/dev/null || true
-		rm -rf .terraform 2>/dev/null || true
-	fi
-fi
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -15,34 +15,20 @@ DEPLOY_APP=1
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment with detailed logging
-echo "[DEBUG] Starting environment detection..."
-echo "[DEBUG] Checking for azlocal command..."
-if command -v azlocal >/dev/null 2>&1; then
-	echo "[DEBUG] azlocal command exists, attempting to query environment..."
-	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
-	AZLOCAL_EXIT_CODE=$?
-	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
-	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
-else
-	echo "[DEBUG] azlocal command not found"
-	ENVIRONMENT=""
-fi
+# Determine environment
+if command -v az >/dev/null 2>&1; then
+	CLOUD_NAME=$(az cloud show --query name --output tsv 2>&1 || echo "")
 
-if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
-	AZ_EXIT_CODE=$?
-	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
-	echo "[DEBUG] az output: '$ENVIRONMENT'"
-
-	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
-		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+	if [[ "$CLOUD_NAME" == "LocalStack" ]]; then
+		ENVIRONMENT="LocalStack"
+	elif [[ "$CLOUD_NAME" == "AzureCloud" ]]; then
+		ENVIRONMENT="AzureCloud"
+	else
 		ENVIRONMENT="AzureCloud"
 	fi
+else
+	ENVIRONMENT="AzureCloud"
 fi
-
-echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -55,7 +41,7 @@ else
 	AZ="az"
 fi
 
-echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -59,6 +59,11 @@ fi
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
+# Enable Terraform debug logging
+export TF_LOG=DEBUG
+export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
+
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade
 
@@ -75,6 +80,11 @@ $TERRAFORM plan -out=tfplan \
 
 if [[ $? != 0 ]]; then
 	echo "Terraform plan failed. Exiting."
+	echo "============================================================"
+	echo "Last 100 lines of Terraform debug log:"
+	echo "============================================================"
+	tail -100 "$TF_LOG_PATH" 2>/dev/null || echo "Debug log not found"
+	echo "============================================================"
 	exit 1
 fi
 

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -44,10 +44,6 @@ if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
 	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
 
-	# Unset Azure auth environment variables to prevent interference from CI secrets
-	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
-	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
-
 	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -285,7 +285,11 @@ else
 fi
 
 # Remove the zip package of the web app
-# Remove the zip package of the web app
 if [ -f "$ZIPFILE" ]; then
 	rm "$ZIPFILE"
 fi
+
+# Clean up Terraform resources
+echo "Cleaning up Terraform resources..."
+cd "$CURRENT_DIR" || exit
+$TERRAFORM destroy -auto-approve

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -34,6 +34,21 @@ fi
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
 	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
+
+	# Log Azure auth environment variables before unsetting
+	echo "[DEBUG] Azure auth env vars before unsetting:"
+	echo "[DEBUG]   ARM_CLIENT_ID=${ARM_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_CLIENT_SECRET=${ARM_CLIENT_SECRET:+<set but hidden>}${ARM_CLIENT_SECRET:-<not set>}"
+	echo "[DEBUG]   ARM_TENANT_ID=${ARM_TENANT_ID:-<not set>}"
+	echo "[DEBUG]   ARM_SUBSCRIPTION_ID=${ARM_SUBSCRIPTION_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-<not set>}"
+	echo "[DEBUG]   AZURE_TENANT_ID=${AZURE_TENANT_ID:-<not set>}"
+
+	# Unset Azure auth environment variables to prevent interference from CI secrets
+	unset ARM_CLIENT_ID ARM_CLIENT_SECRET ARM_TENANT_ID ARM_SUBSCRIPTION_ID
+	unset AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+
+	echo "[DEBUG] Azure auth env vars after unsetting: all cleared"
 	AZ="azlocal"
 else
 	echo "Using standard terraform and az for AzureCloud environment."
@@ -42,6 +57,7 @@ else
 fi
 
 echo "[DEBUG] Cloud name: '$CLOUD_NAME', Environment: '$ENVIRONMENT', Tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
+echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo 'not found')"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -10,15 +10,22 @@ DATABASE_USER_NAME='testuser'
 DATABASE_USER_PASSWORD='TestP@ssw0rd123'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 DEPLOY_APP=1
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
+# Determine environment - check if azlocal is configured first
+ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
+
+if [[ -z "$ENVIRONMENT" ]]; then
+	# Try with regular az if azlocal failed
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+fi
+
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using tflocal and azlocal for LocalStack emulator environment and ."
+	echo "Using tflocal and azlocal for LocalStack emulator environment."
 	TERRAFORM="tflocal"
 	AZ="azlocal"
 else
@@ -56,10 +63,10 @@ if [[ $? != 0 ]]; then
 fi
 
 # Get the output values
-RESOURCE_GROUP_NAME=$(terraform output -raw resource_group_name)
-WEB_APP_NAME=$(terraform output -raw web_app_name)
-SQL_SERVER_NAME=$(terraform output -raw sql_server_name)
-SQL_DATABASE_NAME=$(terraform output -raw sql_database_name)
+RESOURCE_GROUP_NAME=$($TERRAFORM output -raw resource_group_name)
+WEB_APP_NAME=$($TERRAFORM output -raw web_app_name)
+SQL_SERVER_NAME=$($TERRAFORM output -raw sql_server_name)
+SQL_DATABASE_NAME=$($TERRAFORM output -raw sql_database_name)
 
 if [[ -z "$WEB_APP_NAME" || -z "$SQL_SERVER_NAME" || -z "$SQL_DATABASE_NAME" ]]; then
 	echo "Web App Name, SQL Server Name, or SQL Database Name is empty. Exiting."

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -15,13 +15,34 @@ DEPLOY_APP=1
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Determine environment - check if azlocal is configured first
-ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>/dev/null || echo "")
-
-if [[ -z "$ENVIRONMENT" ]]; then
-	# Try with regular az if azlocal failed
-	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || echo "AzureCloud")
+# Determine environment with detailed logging
+echo "[DEBUG] Starting environment detection..."
+echo "[DEBUG] Checking for azlocal command..."
+if command -v azlocal >/dev/null 2>&1; then
+	echo "[DEBUG] azlocal command exists, attempting to query environment..."
+	ENVIRONMENT=$(azlocal account show --query environmentName --output tsv 2>&1)
+	AZLOCAL_EXIT_CODE=$?
+	echo "[DEBUG] azlocal exit code: $AZLOCAL_EXIT_CODE"
+	echo "[DEBUG] azlocal output: '$ENVIRONMENT'"
+else
+	echo "[DEBUG] azlocal command not found"
+	ENVIRONMENT=""
 fi
+
+if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+	echo "[DEBUG] azlocal failed or returned empty, trying standard az..."
+	ENVIRONMENT=$(az account show --query environmentName --output tsv 2>&1)
+	AZ_EXIT_CODE=$?
+	echo "[DEBUG] az exit code: $AZ_EXIT_CODE"
+	echo "[DEBUG] az output: '$ENVIRONMENT'"
+
+	if [[ -z "$ENVIRONMENT" || "$ENVIRONMENT" == *"ERROR"* || "$ENVIRONMENT" == *"error"* ]]; then
+		echo "[DEBUG] Both azlocal and az failed, defaulting to AzureCloud"
+		ENVIRONMENT="AzureCloud"
+	fi
+fi
+
+echo "[DEBUG] Final detected environment: '$ENVIRONMENT'"
 
 # Run terraform init and apply
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -33,6 +54,8 @@ else
 	TERRAFORM="terraform"
 	AZ="az"
 fi
+
+echo "[DEBUG] Selected tools: TERRAFORM=$TERRAFORM, AZ=$AZ"
 
 echo "Initializing Terraform..."
 $TERRAFORM init -upgrade

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -124,7 +124,8 @@ sqlcmd -S "$SQL_SERVER_FQDN" \
 	-d master \
 	-U "$ADMIN_USER" \
 	-P "$ADMIN_PASSWORD" \
-	-Q "IF NOT EXISTS (SELECT * FROM sys.sql_logins WHERE name = '$DATABASE_USER_NAME') 
+	-C \
+	-Q "IF NOT EXISTS (SELECT * FROM sys.sql_logins WHERE name = '$DATABASE_USER_NAME')
 			CREATE LOGIN [$DATABASE_USER_NAME] WITH PASSWORD = '$DATABASE_USER_PASSWORD';" \
 	-V 1
 
@@ -141,7 +142,8 @@ sqlcmd -S "$SQL_SERVER_FQDN" \
 	-d "$SQL_DATABASE_NAME" \
 	-U "$ADMIN_USER" \
 	-P "$ADMIN_PASSWORD" \
-	-Q "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = '$DATABASE_USER_NAME') 
+	-C \
+	-Q "IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = '$DATABASE_USER_NAME')
       CREATE USER [$DATABASE_USER_NAME] FOR LOGIN [$DATABASE_USER_NAME];" \
 	-V 1
 
@@ -158,7 +160,8 @@ sqlcmd -S "$SQL_SERVER_FQDN" \
 	-d "$SQL_DATABASE_NAME" \
 	-U "$ADMIN_USER" \
 	-P "$ADMIN_PASSWORD" \
-	-Q "ALTER ROLE db_datareader ADD MEMBER [$DATABASE_USER_NAME]; 
+	-C \
+	-Q "ALTER ROLE db_datareader ADD MEMBER [$DATABASE_USER_NAME];
 			ALTER ROLE db_datawriter ADD MEMBER [$DATABASE_USER_NAME];
 			ALTER ROLE db_ddladmin ADD MEMBER [$DATABASE_USER_NAME];" \
 	-V 1
@@ -176,6 +179,7 @@ sqlcmd -S "$SQL_SERVER_FQDN" \
 	-d "$SQL_DATABASE_NAME" \
 	-U "$DATABASE_USER_NAME" \
 	-P "$DATABASE_USER_PASSWORD" \
+	-C \
 	-Q "SELECT SYSTEM_USER AS CurrentUser, DB_NAME() AS CurrentDatabase, GETDATE() AS CurrentTime;" \
 	-V 1
 
@@ -192,6 +196,7 @@ sqlcmd -S "$SQL_SERVER_FQDN" \
 	-d "$SQL_DATABASE_NAME" \
 	-U "$DATABASE_USER_NAME" \
 	-P "$DATABASE_USER_PASSWORD" \
+	-C \
 	-Q "IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'Activities' AND schema_id = SCHEMA_ID('dbo'))
 		CREATE TABLE dbo.Activities (
 			-- Primary Key: UNIQUEIDENTIFIER with a default of a new sequential GUID (best for indexing)
@@ -221,8 +226,9 @@ sqlcmd -S "$SQL_SERVER_FQDN" \
 	-d "$SQL_DATABASE_NAME" \
 	-U "$DATABASE_USER_NAME" \
 	-P "$DATABASE_USER_PASSWORD" \
-	-Q "INSERT INTO Activities (username, activity, timestamp) 
-			VALUES 
+	-C \
+	-Q "INSERT INTO Activities (username, activity, timestamp)
+			VALUES
 			('paolo', 'Go to Paris', GETDATE()),
 			('paolo', 'Go to London', GETDATE()),
 			('paolo', 'Go to Mexico', GETDATE());" \
@@ -241,6 +247,7 @@ sqlcmd -S "$SQL_SERVER_FQDN" \
 	-d "$SQL_DATABASE_NAME" \
 	-U "$DATABASE_USER_NAME" \
 	-P "$DATABASE_USER_PASSWORD" \
+	-C \
 	-Q "SELECT * FROM Activities;" \
 	-V 1
 

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -58,6 +58,7 @@ echo "[DEBUG] TERRAFORM command location: $(which $TERRAFORM 2>/dev/null || echo
 # Enable Terraform debug logging
 export TF_LOG=DEBUG
 export TF_LOG_PATH="$CURRENT_DIR/terraform-debug.log"
+echo "[DEBUG] Checking what tflocal does..."echo "[DEBUG] tflocal version: $($TERRAFORM version 2>&1 | head -1)"echo "[DEBUG] Contents of current directory before init:"ls -la . 2>&1 | head -20
 echo "[DEBUG] Terraform debug logging enabled: TF_LOG=DEBUG, TF_LOG_PATH=$TF_LOG_PATH"
 
 echo "Initializing Terraform..."

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -17,11 +17,8 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  subscription_id = "00000000-0000-0000-0000-000000000000"
-  tenant_id       = "00000000-0000-0000-0000-000000000000"
-  client_id       = "00000000-0000-0000-0000-000000000000"
-  client_secret   = "fake-secret"
-
-  use_cli = false
+  # Use Azure CLI authentication (which azlocal intercepts)
+  use_cli = true
   use_msi = false
+  use_oidc = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -10,6 +10,25 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+
+  # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  skip_provider_registration = true
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -18,17 +18,4 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
-
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  skip_provider_registration = true
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  use_cli = false
-  use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>4.44.0"
+      version = "=4.14.0"
     }
   }
 }
@@ -17,10 +17,16 @@ provider "azurerm" {
   }
 
   # LocalStack Azure emulator configuration
-  # Use Azure CLI authentication (which azlocal intercepts)
+  # Uses fixed credentials that tflocal intercepts via HTTPS proxy
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  use_cli  = true
-  use_msi  = false
-  use_oidc = false
+  # Skip provider registration - LocalStack doesn't support this API
+  skip_provider_registration = true
+
+  # Disable CLI/MSI authentication - use static credentials instead
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -18,4 +18,17 @@ provider "azurerm" {
 
   # LocalStack Azure emulator uses a fixed subscription id
   subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  # The following configs are required for local testing
+  # Skip provider registration and authentication for LocalStack
+  resource_provider_registrations = "none"
+
+  # Use environment variables or static values for LocalStack
+  tenant_id     = "00000000-0000-0000-0000-000000000000"
+  client_id     = "00000000-0000-0000-0000-000000000000"
+  client_secret = "fake-secret"
+
+  # Disable authentication checks
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -16,19 +16,13 @@ provider "azurerm" {
     }
   }
 
-  # LocalStack Azure emulator uses a fixed subscription id
+  # LocalStack Azure emulator configuration
   subscription_id = "00000000-0000-0000-0000-000000000000"
+  tenant_id       = "00000000-0000-0000-0000-000000000000"
+  client_id       = "00000000-0000-0000-0000-000000000000"
+  client_secret   = "fake-secret"
 
-  # The following configs are required for local testing
-  # Skip provider registration and authentication for LocalStack
-  resource_provider_registrations = "none"
-
-  # Use environment variables or static values for LocalStack
-  tenant_id     = "00000000-0000-0000-0000-000000000000"
-  client_id     = "00000000-0000-0000-0000-000000000000"
-  client_secret = "fake-secret"
-
-  # Disable authentication checks
-  #use_cli = false
-  #use_msi = false
+  # Disable CLI and MSI authentication
+  use_cli = false
+  use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -22,7 +22,7 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Disable CLI and MSI authentication
-  use_cli = false
+  # Use Azure CLI (azlocal) for authentication
+  use_cli = true
   use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -29,6 +29,6 @@ provider "azurerm" {
   client_secret = "fake-secret"
 
   # Disable authentication checks
-  use_cli = false
-  use_msi = false
+  #use_cli = false
+  #use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -18,7 +18,9 @@ provider "azurerm" {
 
   # LocalStack Azure emulator configuration
   # Use Azure CLI authentication (which azlocal intercepts)
-  use_cli = true
-  use_msi = false
+  subscription_id = "00000000-0000-0000-0000-000000000000"
+
+  use_cli  = true
+  use_msi  = false
   use_oidc = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -22,7 +22,6 @@ provider "azurerm" {
   client_id       = "00000000-0000-0000-0000-000000000000"
   client_secret   = "fake-secret"
 
-  # Use Azure CLI (azlocal) for authentication
-  use_cli = true
+  use_cli = false
   use_msi = false
 }

--- a/samples/web-app-sql-database/python/terraform/terraform.tfvars
+++ b/samples/web-app-sql-database/python/terraform/terraform.tfvars
@@ -1,2 +1,2 @@
 location            = "westeurope"
-python_version      = "3.13"
+python_version      = "3.12"

--- a/samples/web-app-sql-database/python/terraform/variables.tf
+++ b/samples/web-app-sql-database/python/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "prefix" {
   description = "(Optional) Specifies the prefix for the name of the Azure resources."
   type        = string
-  default     = "local"
+  default     = "websql"
 
   validation {
     condition     = var.prefix == null || length(var.prefix) >= 2

--- a/samples/web-app-sql-database/python/terraform/variables.tf
+++ b/samples/web-app-sql-database/python/terraform/variables.tf
@@ -275,13 +275,12 @@ variable "sku_name" {
 }
 
 variable "python_version" {
-  description = "(Optional) Specifies the version of Python to run. Possible values include 3.13, 3.12, 3.11, 3.10, 3.9, 3.8 and 3.7."
+  description = "(Optional) Specifies the version of Python to run. Possible values include 3.12, 3.11, 3.10, 3.9, 3.8 and 3.7."
   type        = string
-  default     = "3.13"
+  default     = "3.12"
 
   validation {
     condition = contains([
-      "3.13",
       "3.12",
       "3.11",
       "3.10",

--- a/samples/web-app-sql-database/python/terraform/variables.tf
+++ b/samples/web-app-sql-database/python/terraform/variables.tf
@@ -160,7 +160,7 @@ variable "license_type" {
   type        = string
   default     = null
   validation {
-    condition     = var.license_type == null || contains(["LicenseIncluded", "BasePrice"], var.license_type)
+    condition     = var.license_type == null || try(contains(["LicenseIncluded", "BasePrice"], var.license_type), false)
     error_message = "License type must be 'LicenseIncluded' or 'BasePrice'."
   }
 }


### PR DESCRIPTION
## Changes

1.  All Terraform tests used the same resource group name "local-rg", causing conflicts when tests ran in parallel on CI. Changes include assigning unique prefixes to each test sample.
2. Sqlcmd with ODBC Driver 18 rejects LocalStack's self-signed SSL certificate by default therefore added -C flag (trust server certificate) to all sqlcmd commands.
3. Not all terraform commands work with python 3.13 so had to revert to python 3.12.
4. Due to disk usage limit error, function app deployment timeout errors, I now run tests in 4 shards instead of 2 allowing more resources free resources per test.

## To Do:

1. For one of the test i.e. function-app-managed-identity sometimes we get the error: 

Status Code: 500, Details: {"error": true, "exception": "URLError", "message": "<urlopen error timed out>"}

This is a results of the function _check_function_status in our function deployer code which has a timeout set to 1 second for the urlopen. This needs to be increased. 

2. The runners we use to run these large sample tests are relatively weak and can result in timeouts and errors such as API rate limit error. In the future we need to either upgrade these runners or move to a repo that allows for powerful runners.

