### PR TITLE
Fix URLs to sample folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ This repository contains comprehensive sample projects demonstrating how to deve
 
 | Sample Name | Description |
 |-------------|-------------|
-| [Function App and Storage](./samples/function-app-storage-http/dotnet/README.md) | Azure Functions App using Blob, Queue, and Table Storage |
-| [Function App and Front Door](./samples/function-app-front-door/python/README.md) | Azure Functions App exposed via Front Door |
-| [Function App and Managed Identities](./samples/function-app-managed-identity/python/README.md) | Azure Function App using Managed Identities | 
-| [Web App and CosmosDB ](./samples/web-app-cosmosdb-mongodb-api/python/README.md) | Azure Web App using CosmosDB for MongoDB API | 
-| [Web App and Managed Identities](./samples/web-app-managed-identity/python/README.md) | Azure Web App using Managed Identities | 
-| [Web App and SQL Database ](./samples/web-app-sql-database/python/README.md) | Azure Web App using SQL Database | 
+| [Function App and Storage](./samples/function-app-storage-http/dotnet) | Azure Functions App using Blob, Queue, and Table Storage |
+| [Function App and Front Door](./samples/function-app-front-door/python/) | Azure Functions App exposed via Front Door |
+| [Function App and Managed Identities](./samples/function-app-managed-identity/python/) | Azure Function App using Managed Identities | 
+| [Web App and CosmosDB ](./samples/web-app-cosmosdb-mongodb-api/python/) | Azure Web App using CosmosDB for MongoDB API | 
+| [Web App and Managed Identities](./samples/web-app-managed-identity/python/) | Azure Web App using Managed Identities | 
+| [Web App and SQL Database ](./samples/web-app-sql-database/python/) | Azure Web App using SQL Database | 
  
 ## Sample Structure
 

--- a/samples/web-app-sql-database/python/README.md
+++ b/samples/web-app-sql-database/python/README.md
@@ -1,6 +1,7 @@
 # Azure Web App with Azure SQL Database and Azure Key Vault
 
-This sample demonstrates a Python Flask single-page web application called *Vacation Planner* hosted on an [Azure Web App](https://learn.microsoft.com/en-us/azure/app-service/overview). The app runs on an Azure App Service Plan and stores activity data in an `activities` table within the `sampledb` database on an [Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/) instance.
+This sample demonstrates a Python Flask single-page web application called *Vacation Planner* hosted on an [Azure Web App](https://learn.microsoft.com/en-us/azure/app-service/overview). The app runs on an Azure App Service Plan and stores activity data in an `activities` table within the `sampledb` database on an [Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/) instance. The connection string of the SQL database is stored as a secret in [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/overview).
+
 
 ## Architecture
 
@@ -11,6 +12,7 @@ The following diagram illustrates the architecture of the solution:
 - **Azure Web App**: Hosts the Python Flask application
 - **Azure App Service Plan**: Provides compute resources for the web app
 - **Azure SQL Database**: Stores activity data in a relational table
+- **Azure Key Vault**: Stores the database connection string
 
 ## Prerequisites
 


### PR DESCRIPTION
This pull request fixes the URL in the main `README.md` to point to the samples folder rather than directly to their `README.md` file.