### PR TITLE
change localstack start command

### DIFF
--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -137,11 +137,10 @@ jobs:
 
       - name: Start LocalStack
         # Run the emulator in detached mode using the virtual environment.
-        # We use 'python -m localstack.cli.main' to ensure the correct CLI version from the venv is used.
         run: |
           source .venv/bin/activate
-          python -m localstack.cli.main start -d
-          python -m localstack.cli.main wait -t 120
+          localstack start -d
+          localstack wait -t 120
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -139,8 +139,8 @@ jobs:
         # Run the emulator in detached mode using the virtual environment.
         run: |
           source .venv/bin/activate
-          localstack start -d
-          localstack wait -t 120
+          python -m localstack_cli.cli.main start -d
+          python -m localstack_cli.cli.main wait -t 120
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}


### PR DESCRIPTION
The localstack 4.14.0 release (Feb 26) migrated the CLI package namespace from localstack.* to localstack_cli.* as part of the uv migration work in the upstream repos. This broke the "Start LocalStack" CI step which used python -m localstack.cli.main, since that module no longer exists in the new package.

Updated the CLI invocation from python -m localstack.cli.main to python -m localstack_cli.cli.main to match the new package structure.