### PR TITLE
Upgrade to azlocal>=0.2.0

### DIFF
--- a/run-samples.sh
+++ b/run-samples.sh
@@ -117,7 +117,7 @@ if command -v azlocal >/dev/null 2>&1; then
   echo "[DEBUG] azlocal command found, attempting login..."
   azlocal login || true
   echo "[DEBUG] Starting azlocal interception..."
-  azlocal start_interception
+  azlocal start-interception
   echo "[DEBUG] Setting default subscription..."
   azlocal account set --subscription "00000000-0000-0000-0000-000000000000" || true
   echo "[DEBUG] Checking azlocal account status..."

--- a/samples/function-app-front-door/python/scripts/cleanup_all.sh
+++ b/samples/function-app-front-door/python/scripts/cleanup_all.sh
@@ -60,7 +60,7 @@ INTERCEPTION_STARTED="false"
 AZURE_CONFIG_DIR_CREATED="false"
 finish() {
   if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
-    set +e; azlocal stop_interception >/dev/null 2>&1 || true; set -e
+    set +e; azlocal stop-interception >/dev/null 2>&1 || true; set -e
   fi
   if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
     rm -rf "$AZURE_CONFIG_DIR"
@@ -76,7 +76,7 @@ if [[ "$USE_LOCALSTACK" == "true" ]]; then
     echo "Error: --use-localstack specified but 'azlocal' was not found in PATH." >&2
     exit 1
   fi
-  if azlocal start_interception; then
+  if azlocal start-interception; then
     INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
   else
     echo "Error: azlocal failed to start interception. Ensure LocalStack is running and azlocal is configured correctly." >&2

--- a/samples/function-app-front-door/python/scripts/deploy_all.sh
+++ b/samples/function-app-front-door/python/scripts/deploy_all.sh
@@ -155,7 +155,7 @@ finish() {
   [[ -f "$ZIP_A" ]] && rm -f "$ZIP_A"
   [[ -f "$ZIP_B" ]] && rm -f "$ZIP_B"
   if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
-    azlocal stop_interception >/dev/null 2>&1 || true
+    azlocal stop-interception >/dev/null 2>&1 || true
   fi
   if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
     rm -rf "$AZURE_CONFIG_DIR"
@@ -176,7 +176,7 @@ if [[ "$USE_LOCALSTACK" == "true" ]]; then
     echo "Error: --use-localstack specified but 'azlocal' not found in PATH." >&2
     exit 1
   fi
-  if azlocal start_interception; then
+  if azlocal start-interception; then
     INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
   else
     echo "Error: azlocal failed to start interception. Ensure LocalStack is running." >&2

--- a/samples/function-app-managed-identity/python/bicep/README.md
+++ b/samples/function-app-managed-identity/python/bicep/README.md
@@ -55,7 +55,7 @@ param runtimeVersion = '3.13'
 The [deploy.sh](deploy.sh) script automates the deployment of all Azure resources and the sample application in a single step. Before running the script, customize the variable values based on your needs. In particular, use the `MANAGED_IDENTITY_TYPE` variable to specify the type of managed identity to provision: `SystemAssigned` or `UserAssigned`.
 
 > **Note**  
-> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start_interception` to automatically intercept and redirect all `az` commands to LocalStack. For more information, see [Get started with the az tool on LocalStack](https://azure.localstack.cloud/user-guides/sdks/az/).
+> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start-interception` to automatically intercept and redirect all `az` commands to LocalStack. For more information, see [Get started with the az tool on LocalStack](https://azure.localstack.cloud/user-guides/sdks/az/).
 
 The [deploy.sh](deploy.sh) script executes the following steps:
 

--- a/samples/function-app-managed-identity/python/scripts/README.md
+++ b/samples/function-app-managed-identity/python/scripts/README.md
@@ -46,7 +46,7 @@ This sample provides two Bash scripts to streamline the deployment process by au
 These scripts eliminate manual configuration steps and enable one-command deployment of the entire infrastructure.
 
 > [!NOTE]
-> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start_interception` to automatically intercept and redirect all `az` commands to LocalStack. To revert back to the default behavior and send commands to the Azure cloud, run `azlocal stop_interception`.
+> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start-interception` to automatically intercept and redirect all `az` commands to LocalStack. To revert back to the default behavior and send commands to the Azure cloud, run `azlocal stop-interception`.
 
 
 ## Deployment

--- a/samples/function-app-managed-identity/python/terraform/README.md
+++ b/samples/function-app-managed-identity/python/terraform/README.md
@@ -42,7 +42,7 @@ For more information on the sample application, see [Azure Functions App with Ma
 The [deploy.sh](deploy.sh) script automates the deployment of all Azure resources and the sample application in a single step. Before running the script, customize the variable values based on your needs. In particular, use the `MANAGED_IDENTITY_TYPE` variable to specify the type of managed identity to provision: `SystemAssigned` or `UserAssigned`.
 
 > **Note**  
-> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start_interception` to automatically intercept and redirect all `az` commands to LocalStack. Likewise, the `tflocal` is a local replacement for the standard `terraform` CLI, allowing you to run Terraform commands against LocalStack's Azure emulation environment. For more information, see [Get started with the az tool on LocalStack](https://azure.localstack.cloud/user-guides/sdks/az/).
+> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start-interception` to automatically intercept and redirect all `az` commands to LocalStack. Likewise, the `tflocal` is a local replacement for the standard `terraform` CLI, allowing you to run Terraform commands against LocalStack's Azure emulation environment. For more information, see [Get started with the az tool on LocalStack](https://azure.localstack.cloud/user-guides/sdks/az/).
 
 The [deploy.sh](deploy.sh) script executes the following steps:
 

--- a/samples/function-app-storage-http/dotnet/scripts/README.md
+++ b/samples/function-app-storage-http/dotnet/scripts/README.md
@@ -116,7 +116,7 @@ The script configures the following application settings for the gaming system:
 
 ### LocalStack-Specific Commands
 
-1. `azlocal start_interception`:
+1. `azlocal start-interception`:
    - Redirects Azure CLI calls to LocalStack endpoints
    - Enables local development without Azure subscription
    - Maintains compatibility with standard Azure CLI syntax
@@ -126,7 +126,7 @@ The script configures the following application settings for the gaming system:
    - Wraps the Azure Functions Core Tools
    - Provides local testing environment for Azure Functions
 
-3. `azlocal stop_interception`:
+3. `azlocal stop-interception`:
    - Restores normal Azure CLI behavior
    - Cleans up LocalStack session state
    - Returns CLI to standard Azure cloud operations

--- a/samples/servicebus/java/scripts/deploy.sh
+++ b/samples/servicebus/java/scripts/deploy.sh
@@ -13,7 +13,7 @@ SERVICEBUS_QUEUE_NAME="myqueue"
 cd "$CURRENT_DIR" || exit
 
 # Redirect AZ calls to LocalStack
-azlocal start_interception
+azlocal start-interception
 
 # Create a resource group
 echo "Creating resource group [$RESOURCE_GROUP_NAME]..."
@@ -45,6 +45,6 @@ az group delete \
     --name $RESOURCE_GROUP_NAME \
     --yes
 
-azlocal stop_interception
+azlocal stop-interception
 
 

--- a/samples/web-app-managed-identity/python/scripts/README.md
+++ b/samples/web-app-managed-identity/python/scripts/README.md
@@ -66,7 +66,7 @@ See the script files for complete implementation. The scripts perform the follow
 These scripts eliminate manual configuration steps and enable one-command deployment of the entire infrastructure.
 
 > [!NOTE]
-> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start_interception` to automatically intercept and redirect all `az` commands to LocalStack. To revert back to the default behavior and send commands to the Azure cloud, run `azlocal stop_interception`.
+> You can use the `azlocal` CLI as a drop-in replacement for the `az` CLI to direct all commands to the LocalStack for Azure emulator. Alternatively, run `azlocal start-interception` to automatically intercept and redirect all `az` commands to LocalStack. To revert back to the default behavior and send commands to the Azure cloud, run `azlocal stop-interception`.
 
 ## Deployment
 


### PR DESCRIPTION
## Motivation

The `azlocal` tool has changed it's commands to use `kebab-case`, instead of `lower_case` asof version 0.2.0 - see https://github.com/localstack/azcli-local/pull/33. 

This PR updates all invocations and README's to use `start-interception` and `stop-interception`.