### PR TITLE
[Azure:CosmosDB] - Add CLI commands to script

### DIFF
--- a/samples/web-app-cosmosdb-nosql-api/python/scripts/deploy.sh
+++ b/samples/web-app-cosmosdb-nosql-api/python/scripts/deploy.sh
@@ -15,6 +15,7 @@ RANDOM_SUFFIX=$(echo $RANDOM)
 NEW_DB_NAME="vacationplanner_${RANDOM_SUFFIX}"
 AZURECOSMOSDB_DATABASENAME=$NEW_DB_NAME
 AZURECOSMOSDB_CONTAINERNAME="activities_${RANDOM_SUFFIX}"
+AURECOSMOSDB_PARTITION_KEY="/partitionKey"
 
 # Start azure CLI local mode session
 azlocal login
@@ -56,6 +57,21 @@ echo "Create CosmosDB NoSQL Account"
 
 echo "Account created"
 echo "AZURECOSMOSDB_ENDPOINT set to $AZURECOSMOSDB_ENDPOINT"
+
+echo "Create CosmosDB NoSQL Database"
+azlocal cosmosdb sql database create \
+    --resource-group $RESOURCE_GROUP_NAME \
+    --name $AZURECOSMOSDB_DATABASENAME \
+    --account-name $WEB_APP_NAME
+
+echo "Create CosmosDB NoSQL Container"
+azlocal cosmosdb sql container create \
+    --resource-group $RESOURCE_GROUP_NAME \
+    --account-name $WEB_APP_NAME \
+    --database-name $AZURECOSMOSDB_DATABASENAME \
+    --name $AZURECOSMOSDB_CONTAINERNAME \
+    --partition-key-path $AURECOSMOSDB_PARTITION_KEY \
+    --throughput 400
 
 echo "Fetching DB Account primary master key"
 export AZURECOSMOSDB_PRIMARY_KEY=$(azlocal cosmosdb keys list \


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation
After implementing the CLI commands for creating databases and containers, they should be added to the deploy script of the sample.

<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
This PR adds the CLI operations for creating databases and containers to the deploy script of the sample application

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
