### PR TITLE
Replace `azlocal` with `az`

### DIFF
--- a/samples/aci-blob-storage/python/bicep/deploy.sh
+++ b/samples/aci-blob-storage/python/bicep/deploy.sh
@@ -16,7 +16,6 @@ SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 IMAGE_NAME="vacation-planner"
 IMAGE_TAG="v1"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 echo "=================================================="
 echo "DEBUG: Starting bicep deployment for aci-blob-storage"
@@ -26,26 +25,16 @@ echo "=================================================="
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -68,7 +57,7 @@ fi
 # Create ACR first so we can push the image
 ACR_NAME="${PREFIX}aciacr${SUFFIX}"
 echo "Creating ACR [$ACR_NAME] for image push..."
-$AZ acr create \
+az acr create \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--location "$LOCATION" \
@@ -76,21 +65,21 @@ $AZ acr create \
 	--admin-enabled true \
 	--only-show-errors 1>/dev/null
 
-LOGIN_SERVER=$($AZ acr show \
+LOGIN_SERVER=$(az acr show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "loginServer" \
 	--output tsv \
 	--only-show-errors)
 
-ACR_USERNAME=$($AZ acr credential show \
+ACR_USERNAME=$(az acr credential show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "username" \
 	--output tsv \
 	--only-show-errors)
 
-ACR_PASSWORD=$($AZ acr credential show \
+ACR_PASSWORD=$(az acr credential show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "passwords[0].value" \
@@ -130,7 +119,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -148,7 +137,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -169,7 +158,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \

--- a/samples/aci-blob-storage/python/scripts/cleanup.sh
+++ b/samples/aci-blob-storage/python/scripts/cleanup.sh
@@ -15,7 +15,6 @@ ACI_GROUP_ADVANCED="${PREFIX}-aci-planner-advanced"
 KEY_VAULT_NAME="${PREFIX}acikv"
 ACR_NAME="${PREFIX}aciacr"
 STORAGE_ACCOUNT_NAME="${PREFIX}acistorage"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Choose the appropriate CLI based on the environment
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -31,13 +30,13 @@ echo ""
 
 # 1. Delete ACI container groups (basic + advanced)
 echo "[1/5] Deleting ACI container groups..."
-$AZ container delete \
+az container delete \
 	--name "$ACI_GROUP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--yes \
 	--only-show-errors 2>/dev/null && echo "  Deleted: $ACI_GROUP_NAME" || echo "  Skipped: $ACI_GROUP_NAME (not found)"
 
-$AZ container delete \
+az container delete \
 	--name "$ACI_GROUP_ADVANCED" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--yes \
@@ -46,7 +45,7 @@ echo ""
 
 # 2. Delete ACR
 echo "[2/5] Deleting ACR [$ACR_NAME]..."
-$AZ acr delete \
+az acr delete \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--yes \
@@ -55,18 +54,18 @@ echo ""
 
 # 3. Delete Key Vault (delete + purge to release the vault name)
 echo "[3/5] Deleting Key Vault [$KEY_VAULT_NAME]..."
-$AZ keyvault delete \
+az keyvault delete \
 	--name "$KEY_VAULT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors 2>/dev/null && echo "  Deleted: $KEY_VAULT_NAME" || echo "  Skipped: $KEY_VAULT_NAME (not found)"
-$AZ keyvault purge \
+az keyvault purge \
 	--name "$KEY_VAULT_NAME" \
 	--only-show-errors 2>/dev/null && echo "  Purged: $KEY_VAULT_NAME" || true
 echo ""
 
 # 4. Delete Storage Account
 echo "[4/5] Deleting Storage Account [$STORAGE_ACCOUNT_NAME]..."
-$AZ storage account delete \
+az storage account delete \
 	--name "$STORAGE_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--yes \
@@ -75,7 +74,7 @@ echo ""
 
 # 5. Delete Resource Group
 echo "[5/5] Deleting Resource Group [$RESOURCE_GROUP_NAME]..."
-$AZ group delete \
+az group delete \
 	--name "$RESOURCE_GROUP_NAME" \
 	--yes \
 	--only-show-errors 2>/dev/null && echo "  Deleted: $RESOURCE_GROUP_NAME" || echo "  Skipped: $RESOURCE_GROUP_NAME (not found)"

--- a/samples/aci-blob-storage/python/scripts/deploy.sh
+++ b/samples/aci-blob-storage/python/scripts/deploy.sh
@@ -22,21 +22,10 @@ ACI_GROUP_NAME="${PREFIX}-aci-planner"
 IMAGE_NAME="vacation-planner"
 IMAGE_TAG="v1"
 LOGIN_NAME="paolo"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # =============================================================================
 # Step 1: Create Resource Group
 # =============================================================================
@@ -44,7 +33,7 @@ echo ""
 echo "============================================================"
 echo "Step 1: Creating resource group [$RESOURCE_GROUP_NAME]..."
 echo "============================================================"
-$AZ group create \
+az group create \
 	--name $RESOURCE_GROUP_NAME \
 	--location $LOCATION \
 	--only-show-errors 1>/dev/null
@@ -63,7 +52,7 @@ echo ""
 echo "============================================================"
 echo "Step 2: Creating storage account [$STORAGE_ACCOUNT_NAME]..."
 echo "============================================================"
-$AZ storage account create \
+az storage account create \
 	--name $STORAGE_ACCOUNT_NAME \
 	--location $LOCATION \
 	--resource-group $RESOURCE_GROUP_NAME \
@@ -84,7 +73,7 @@ echo ""
 echo "============================================================"
 echo "Step 3: Retrieving storage account key..."
 echo "============================================================"
-STORAGE_ACCOUNT_KEY=$($AZ storage account keys list \
+STORAGE_ACCOUNT_KEY=$(az storage account keys list \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "[0].value" \
@@ -104,7 +93,7 @@ echo ""
 echo "============================================================"
 echo "Step 4: Retrieving storage blob endpoint..."
 echo "============================================================"
-BLOB_ENDPOINT=$($AZ storage account show \
+BLOB_ENDPOINT=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "primaryEndpoints.blob" \
@@ -142,7 +131,7 @@ echo "Step 5: Creating blob container [$BLOB_CONTAINER_NAME]..."
 echo "============================================================"
 # Use --connection-string to ensure the correct endpoint is used
 # (--account-name constructs its own hostname which may not match LocalStack's cert)
-$AZ storage container create \
+az storage container create \
 	--name $BLOB_CONTAINER_NAME \
 	--connection-string "$STORAGE_CONN_STRING" \
 	--only-show-errors 1>/dev/null
@@ -161,7 +150,7 @@ echo ""
 echo "============================================================"
 echo "Step 6: Creating Key Vault [$KEY_VAULT_NAME]..."
 echo "============================================================"
-KV_OUTPUT=$($AZ keyvault create \
+KV_OUTPUT=$(az keyvault create \
 	--name "$KEY_VAULT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--location "$LOCATION" \
@@ -186,7 +175,7 @@ echo "============================================================"
 echo "Step 7: Storing storage connection string in Key Vault..."
 echo "============================================================"
 # Store the container-friendly connection string so ACI can reach LocalStack
-$AZ keyvault secret set \
+az keyvault secret set \
 	--vault-name "$KEY_VAULT_NAME" \
 	--name "storage-conn" \
 	--value "$CONTAINER_CONN_STRING" \
@@ -200,7 +189,7 @@ else
 fi
 
 # Retrieve secret to verify and pass to ACI
-RETRIEVED_CONN_STRING=$($AZ keyvault secret show \
+RETRIEVED_CONN_STRING=$(az keyvault secret show \
 	--vault-name "$KEY_VAULT_NAME" \
 	--name "storage-conn" \
 	--query "value" \
@@ -221,7 +210,7 @@ echo ""
 echo "============================================================"
 echo "Step 8: Creating ACR [$ACR_NAME] with admin user enabled..."
 echo "============================================================"
-$AZ acr create \
+az acr create \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--location "$LOCATION" \
@@ -243,7 +232,7 @@ echo ""
 echo "============================================================"
 echo "Step 9: Retrieving ACR credentials..."
 echo "============================================================"
-LOGIN_SERVER=$($AZ acr show \
+LOGIN_SERVER=$(az acr show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "loginServer" \
@@ -256,14 +245,14 @@ if [ -z "$LOGIN_SERVER" ]; then
 fi
 echo "ACR Login Server: $LOGIN_SERVER"
 
-ACR_USERNAME=$($AZ acr credential show \
+ACR_USERNAME=$(az acr credential show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "username" \
 	--output tsv \
 	--only-show-errors)
 
-ACR_PASSWORD=$($AZ acr credential show \
+ACR_PASSWORD=$(az acr credential show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "passwords[0].value" \
@@ -333,7 +322,7 @@ echo "Step 11: Creating ACI container group [$ACI_GROUP_NAME]..."
 echo "============================================================"
 
 if [ "$USE_ACR_IMAGE" = true ]; then
-	$AZ container create \
+	az container create \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--name "$ACI_GROUP_NAME" \
 		--image "$FULL_IMAGE" \
@@ -353,7 +342,7 @@ if [ "$USE_ACR_IMAGE" = true ]; then
 		--location "$LOCATION" \
 		--only-show-errors 1>/dev/null
 else
-	$AZ container create \
+	az container create \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--name "$ACI_GROUP_NAME" \
 		--image "$FULL_IMAGE" \

--- a/samples/aci-blob-storage/python/scripts/validate.sh
+++ b/samples/aci-blob-storage/python/scripts/validate.sh
@@ -15,7 +15,6 @@ STORAGE_ACCOUNT_NAME="${PREFIX}acistorage"
 KEY_VAULT_NAME="${PREFIX}acikv"
 ACR_NAME="${PREFIX}aciacr"
 ACI_GROUP_NAME="${PREFIX}-aci-planner"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -71,34 +70,34 @@ echo ""
 
 # 1. Resource Group
 echo "[1/5] Resource Group"
-check "resource group exists" "$AZ group show --name $RESOURCE_GROUP_NAME"
+check "resource group exists" "az group show --name $RESOURCE_GROUP_NAME"
 echo ""
 
 # 2. Storage Account
 echo "[2/5] Storage Account"
-check "storage account exists" "$AZ storage account show --name $STORAGE_ACCOUNT_NAME --resource-group $RESOURCE_GROUP_NAME"
+check "storage account exists" "az storage account show --name $STORAGE_ACCOUNT_NAME --resource-group $RESOURCE_GROUP_NAME"
 echo ""
 
 # 3. Key Vault
 echo "[3/5] Key Vault"
-check "key vault exists" "$AZ keyvault show --name $KEY_VAULT_NAME --resource-group $RESOURCE_GROUP_NAME"
-check "secret exists" "$AZ keyvault secret show --vault-name $KEY_VAULT_NAME --name storage-conn"
+check "key vault exists" "az keyvault show --name $KEY_VAULT_NAME --resource-group $RESOURCE_GROUP_NAME"
+check "secret exists" "az keyvault secret show --vault-name $KEY_VAULT_NAME --name storage-conn"
 echo ""
 
 # 4. Container Registry
 echo "[4/5] Container Registry"
-check "ACR exists" "$AZ acr show --name $ACR_NAME --resource-group $RESOURCE_GROUP_NAME"
+check "ACR exists" "az acr show --name $ACR_NAME --resource-group $RESOURCE_GROUP_NAME"
 echo ""
 
 # 5. Container Instance - Get
 echo "[5/5] Container Instance"
-check "ACI container group exists" "$AZ container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME"
+check "ACI container group exists" "az container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME"
 echo ""
 
 # Wait for the container group to reach Running state before testing operations
 echo -n "  Waiting for container group to be Running... "
 for i in $(seq 1 20); do
-	STATE=$($AZ container show --name "$ACI_GROUP_NAME" --resource-group "$RESOURCE_GROUP_NAME" --query 'instanceView.state' --output tsv 2>/dev/null)
+	STATE=$(az container show --name "$ACI_GROUP_NAME" --resource-group "$RESOURCE_GROUP_NAME" --query 'instanceView.state' --output tsv 2>/dev/null)
 	if [[ "$STATE" == "Running" ]]; then
 		break
 	fi
@@ -119,13 +118,13 @@ echo ""
 
 # Check FQDN is set (after wait, so async creation has completed)
 check_output "FQDN is set" \
-	"$AZ container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'ipAddress.fqdn' --output tsv" \
+	"az container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'ipAddress.fqdn' --output tsv" \
 	"azurecontainer.io"
 
 # 6. List container groups
 echo "[6] List Container Groups"
 check_output "list returns our group" \
-	"$AZ container list --resource-group $RESOURCE_GROUP_NAME --query '[].name' --output tsv" \
+	"az container list --resource-group $RESOURCE_GROUP_NAME --query '[].name' --output tsv" \
 	"$ACI_GROUP_NAME"
 echo ""
 
@@ -135,7 +134,7 @@ echo -n "  Checking container logs for Flask startup... "
 
 # Wait for Flask to start (container may need a few seconds to initialize)
 for i in $(seq 1 15); do
-	LOGS=$($AZ container logs \
+	LOGS=$(az container logs \
 		--name "$ACI_GROUP_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" 2>/dev/null)
 
@@ -177,7 +176,7 @@ echo ""
 # 8. Container Exec
 echo "[8] Container Exec"
 echo -n "  Executing command inside container... "
-EXEC_OUTPUT=$($AZ container exec \
+EXEC_OUTPUT=$(az container exec \
 	--name "$ACI_GROUP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--container-name "$ACI_GROUP_NAME" \
@@ -201,7 +200,7 @@ echo ""
 # 9. Stop
 echo "[9] Stop Container Group"
 echo -n "  Stopping container group... "
-$AZ container stop \
+az container stop \
 	--name "$ACI_GROUP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors 2>/dev/null
@@ -216,14 +215,14 @@ fi
 
 # Verify stopped state
 check_output "state is Stopped" \
-	"$AZ container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'instanceView.state' --output tsv" \
+	"az container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'instanceView.state' --output tsv" \
 	"Stopped"
 echo ""
 
 # 10. Start
 echo "[10] Start Container Group"
 echo -n "  Starting container group... "
-$AZ container start \
+az container start \
 	--name "$ACI_GROUP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors 2>/dev/null
@@ -240,14 +239,14 @@ fi
 sleep 3
 
 check_output "state is Running" \
-	"$AZ container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'instanceView.state' --output tsv" \
+	"az container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'instanceView.state' --output tsv" \
 	"Running"
 echo ""
 
 # 11. Restart
 echo "[11] Restart Container Group"
 echo -n "  Restarting container group... "
-$AZ container restart \
+az container restart \
 	--name "$ACI_GROUP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors 2>/dev/null
@@ -264,7 +263,7 @@ fi
 sleep 3
 
 check_output "state is Running after restart" \
-	"$AZ container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'instanceView.state' --output tsv" \
+	"az container show --name $ACI_GROUP_NAME --resource-group $RESOURCE_GROUP_NAME --query 'instanceView.state' --output tsv" \
 	"Running"
 echo ""
 
@@ -277,7 +276,7 @@ echo "============================================================"
 
 # Show the app URL if a host port is mapped
 HOST_PORT=$(docker port "$(docker ps -q --filter "name=ls-aci-${ACI_GROUP_NAME}" | head -1)" 80/tcp 2>/dev/null | head -1 | sed 's/.*://')
-FQDN=$($AZ container show --name "$ACI_GROUP_NAME" --resource-group "$RESOURCE_GROUP_NAME" --query 'ipAddress.fqdn' --output tsv 2>/dev/null)
+FQDN=$(az container show --name "$ACI_GROUP_NAME" --resource-group "$RESOURCE_GROUP_NAME" --query 'ipAddress.fqdn' --output tsv 2>/dev/null)
 
 if [ -n "$HOST_PORT" ] || [ -n "$FQDN" ]; then
 	echo ""

--- a/samples/aci-blob-storage/python/terraform/deploy.sh
+++ b/samples/aci-blob-storage/python/terraform/deploy.sh
@@ -7,7 +7,6 @@ LOCATION='eastus'
 IMAGE_NAME='vacation-planner'
 IMAGE_TAG='v1'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
@@ -31,13 +30,13 @@ RESOURCE_GROUP_NAME="${PREFIX}-aci-rg"
 ACR_NAME="${PREFIX}aciacr${SUFFIX}"
 
 echo "Creating resource group [$RESOURCE_GROUP_NAME]..."
-$AZ group create \
+az group create \
 	--name "$RESOURCE_GROUP_NAME" \
 	--location "$LOCATION" \
 	--only-show-errors 1>/dev/null
 
 echo "Creating ACR [$ACR_NAME] for image push..."
-$AZ acr create \
+az acr create \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--location "$LOCATION" \
@@ -45,21 +44,21 @@ $AZ acr create \
 	--admin-enabled true \
 	--only-show-errors 1>/dev/null
 
-LOGIN_SERVER=$($AZ acr show \
+LOGIN_SERVER=$(az acr show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "loginServer" \
 	--output tsv \
 	--only-show-errors)
 
-ACR_USERNAME=$($AZ acr credential show \
+ACR_USERNAME=$(az acr credential show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "username" \
 	--output tsv \
 	--only-show-errors)
 
-ACR_PASSWORD=$($AZ acr credential show \
+ACR_PASSWORD=$(az acr credential show \
 	--name "$ACR_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "passwords[0].value" \

--- a/samples/function-app-managed-identity/python/README.md
+++ b/samples/function-app-managed-identity/python/README.md
@@ -92,20 +92,9 @@ INPUT_CONTAINER_NAME="input"
 OUTPUT_CONTAINER_NAME="output"
 STORAGE_ACCOUNT_NAME="${PREFIX}storage${SUFFIX}"
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Generate a timestamp in the format YYYY-MM-DD-HH-MM-SS
 TIMESTAMP=$(date +"%Y-%m-%d-%H-%M-%S")
 
@@ -118,7 +107,7 @@ FILE_EXTENSION="${FILE_NAME##*.}" # File extension
 BLOB_NAME="${FILE_BASE_NAME}-${TIMESTAMP}.${FILE_EXTENSION}"
 
 # Check whether the input container already exists
-CONTAINER_EXISTS=$($AZ storage container exists \
+CONTAINER_EXISTS=$(az storage container exists \
 	--name "$INPUT_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--auth-mode login | jq .exists)
@@ -129,14 +118,14 @@ else
 	echo "Container [$INPUT_CONTAINER_NAME] does not exist."
 
 	# Create the input container if it doesn't exist
-	$AZ storage container create \
+	az storage container create \
 		--name $INPUT_CONTAINER_NAME \
 		--account-name $STORAGE_ACCOUNT_NAME \
 		--auth-mode login
 fi
 
 # Check whether the output container already exists
-CONTAINER_EXISTS=$($AZ storage container exists \
+CONTAINER_EXISTS=$(az storage container exists \
 	--name "$OUTPUT_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--auth-mode login | jq .exists)
@@ -147,14 +136,14 @@ else
 	echo "Container [$OUTPUT_CONTAINER_NAME] does not exist."
 
 	# Create the output container if it doesn't exist
-	$AZ storage container create \
+	az storage container create \
 		--name $OUTPUT_CONTAINER_NAME \
 		--account-name $STORAGE_ACCOUNT_NAME \
 		--auth-mode login
 fi
 
 # Upload the file to the container
-$AZ storage blob upload \
+az storage blob upload \
 	--container-name $INPUT_CONTAINER_NAME \
 	--file "$FILE_PATH" \
 	--name "$BLOB_NAME" \
@@ -164,7 +153,7 @@ $AZ storage blob upload \
 echo "[$BLOB_NAME] file uploaded successfully to the [$INPUT_CONTAINER_NAME] container."
 
 # Verify the upload by checking if the blob exists in the input container
-BLOB_EXISTS=$($AZ storage blob exists \
+BLOB_EXISTS=$(az storage blob exists \
 	--container-name "$INPUT_CONTAINER_NAME" \
 	--name "$BLOB_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
@@ -186,7 +175,7 @@ seconds=5
 for ((i=1; i<=n; i++)); do
 	echo "Checking for [$BLOB_NAME] file in the [$OUTPUT_CONTAINER_NAME] container (Attempt $i of $n)..."
 	
-	BLOB_EXISTS=$($AZ storage blob exists \
+	BLOB_EXISTS=$(az storage blob exists \
 		--container-name "$OUTPUT_CONTAINER_NAME" \
 		--name "$BLOB_NAME" \
 		--account-name "$STORAGE_ACCOUNT_NAME" \

--- a/samples/function-app-managed-identity/python/bicep/README.md
+++ b/samples/function-app-managed-identity/python/bicep/README.md
@@ -113,41 +113,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-managed-identity/python/bicep/deploy.sh
+++ b/samples/function-app-managed-identity/python/bicep/deploy.sh
@@ -13,30 +13,20 @@ USE_WHAT_IF=0
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="function_app.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -56,7 +46,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -75,7 +65,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -97,7 +87,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \
@@ -143,7 +133,7 @@ zip -r "$ZIPFILE" function_app.py host.json requirements.txt
 
 # Deploy the function app
 echo "Deploying function app [$FUNCTION_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ functionapp deploy \
+az functionapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/function-app-managed-identity/python/scripts/README.md
+++ b/samples/function-app-managed-identity/python/scripts/README.md
@@ -90,41 +90,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-managed-identity/python/scripts/system-managed-identity.sh
+++ b/samples/function-app-managed-identity/python/scripts/system-managed-identity.sh
@@ -14,31 +14,21 @@ OUTPUT_STORAGE_CONTAINER_NAME='output'
 ZIPFILE="function_app.zip"
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 RETRY_COUNT=3
 SLEEP=5
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -55,14 +45,14 @@ fi
 
 # Create a storage account
 echo "Checking if storage account [$STORAGE_ACCOUNT_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ storage account show \
+az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No storage account [$STORAGE_ACCOUNT_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating storage account [$STORAGE_ACCOUNT_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ storage account create \
+	az storage account create \
 		--name $STORAGE_ACCOUNT_NAME \
 		--location $LOCATION \
 		--resource-group $RESOURCE_GROUP_NAME \
@@ -80,7 +70,7 @@ fi
 
 # Get the storage account key
 echo "Getting storage account key for [$STORAGE_ACCOUNT_NAME]..."
-STORAGE_ACCOUNT_KEY=$($AZ storage account keys list \
+STORAGE_ACCOUNT_KEY=$(az storage account keys list \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "[0].value" \
@@ -98,7 +88,7 @@ STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=$STORAGE_A
 echo "Storage connection string constructed: [$STORAGE_CONNECTION_STRING]"
 
 # Get the storage account resource ID
-STORAGE_ACCOUNT_RESOURCE_ID=$($AZ storage account show \
+STORAGE_ACCOUNT_RESOURCE_ID=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "id" \
@@ -113,7 +103,7 @@ else
 fi
 
 # Get the storage account blob primary endpoint
-AZURE_STORAGE_ACCOUNT_URL=$($AZ storage account show \
+AZURE_STORAGE_ACCOUNT_URL=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "primaryEndpoints.blob" \
@@ -129,7 +119,7 @@ fi
 
 # Check if the input blob container exists
 echo "Checking if input blob container [$INPUT_STORAGE_CONTAINER_NAME] exists in the [$STORAGE_ACCOUNT_NAME] storage account..."
-$AZ storage container show \
+az storage container show \
 	--name "$INPUT_STORAGE_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--account-key "$STORAGE_ACCOUNT_KEY" &>/dev/null
@@ -138,7 +128,7 @@ if [[ $? != 0 ]]; then
 
 	# Create input blob container
 	echo "Creating input blob container [$INPUT_STORAGE_CONTAINER_NAME] in the [$STORAGE_ACCOUNT_NAME] storage account..."
-	$AZ storage container create \
+	az storage container create \
 		--name "$INPUT_STORAGE_CONTAINER_NAME" \
 		--account-name "$STORAGE_ACCOUNT_NAME" \
 		--account-key "$STORAGE_ACCOUNT_KEY"
@@ -153,7 +143,7 @@ fi
 
 # Check if the output blob container exists
 echo "Checking if output blob container [$OUTPUT_STORAGE_CONTAINER_NAME] exists in the [$STORAGE_ACCOUNT_NAME] storage account..."
-$AZ storage container show \
+az storage container show \
 	--name "$OUTPUT_STORAGE_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--account-key "$STORAGE_ACCOUNT_KEY" &>/dev/null
@@ -161,7 +151,7 @@ $AZ storage container show \
 if [[ $? != 0 ]]; then
 	# Create output blob container
 	echo "Creating output blob container [$OUTPUT_STORAGE_CONTAINER_NAME] in the [$STORAGE_ACCOUNT_NAME] storage account..."
-	$AZ storage container create \
+	az storage container create \
 		--name "$OUTPUT_STORAGE_CONTAINER_NAME" \
 		--account-name "$STORAGE_ACCOUNT_NAME" \
 		--account-key "$STORAGE_ACCOUNT_KEY"
@@ -176,7 +166,7 @@ fi
 
 # Create the function app
 echo "Creating function app [$FUNCTION_APP_NAME]..."
-$AZ functionapp create \
+az functionapp create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--consumption-plan-location $LOCATION \
 	--assign-identity '[system]' \
@@ -196,7 +186,7 @@ else
 fi
 
 # Retrieve the principalId of the system-assigned managed identity
-MANAGED_IDENTITY_PRINCIPAL_ID=$($AZ functionapp identity show \
+MANAGED_IDENTITY_PRINCIPAL_ID=$(az functionapp identity show \
 	--name "$FUNCTION_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query principalId \
@@ -212,7 +202,7 @@ fi
 # Assign the Storage Blob Data Contributor role to the managed identity with the storage account as scope
 ROLE="Storage Blob Data Contributor"
 echo "Checking if the managed identity with principal ID [$MANAGED_IDENTITY_PRINCIPAL_ID] has the [$ROLE] role assignment on storage account [$STORAGE_ACCOUNT_NAME]..."
-current=$($AZ role assignment list \
+current=$(az role assignment list \
 	--assignee "$MANAGED_IDENTITY_PRINCIPAL_ID" \
 	--scope "$STORAGE_ACCOUNT_RESOURCE_ID" \
 	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
@@ -226,7 +216,7 @@ else
 	ATTEMPT=1
 	while [ $ATTEMPT -le $RETRY_COUNT ]; do
 		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
-		$AZ role assignment create \
+		az role assignment create \
 			--assignee "$MANAGED_IDENTITY_PRINCIPAL_ID" \
 			--role "$ROLE" \
 			--scope "$STORAGE_ACCOUNT_RESOURCE_ID" 1>/dev/null
@@ -253,7 +243,7 @@ fi
 # Assign the Storage Queue Data Contributor role to the managed identity with the storage account as scope
 ROLE="Storage Queue Data Contributor"
 echo "Checking if the managed identity with principal ID [$MANAGED_IDENTITY_PRINCIPAL_ID] has the [$ROLE] role assignment on storage account [$STORAGE_ACCOUNT_NAME]..."
-current=$($AZ role assignment list \
+current=$(az role assignment list \
 	--assignee "$MANAGED_IDENTITY_PRINCIPAL_ID" \
 	--scope "$STORAGE_ACCOUNT_RESOURCE_ID" \
 	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
@@ -267,7 +257,7 @@ else
 	ATTEMPT=1
 	while [ $ATTEMPT -le $RETRY_COUNT ]; do
 		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
-		$AZ role assignment create \
+		az role assignment create \
 			--assignee "$MANAGED_IDENTITY_PRINCIPAL_ID" \
 			--role "$ROLE" \
 			--scope "$STORAGE_ACCOUNT_RESOURCE_ID" 1>/dev/null
@@ -300,7 +290,7 @@ QUEUE_SERVICE_URI="https://${STORAGE_ACCOUNT_NAME}.queue.core.windows.net"
 TABLE_SERVICE_URI="https://${STORAGE_ACCOUNT_NAME}.table.core.windows.net"
 	
 
-$AZ functionapp config appsettings set \
+az functionapp config appsettings set \
 	--name $FUNCTION_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--settings \
@@ -337,11 +327,11 @@ zip -r "$ZIPFILE" function_app.py host.json requirements.txt
 
 # Deploy the function app
 echo "Deploying function app [$FUNCTION_APP_NAME] with zip file [$ZIPFILE]..."
-#$AZ functionapp deployment source config-zip \
+#az functionapp deployment source config-zip \
 #	--resource-group "$RESOURCE_GROUP_NAME" \
 #	--name "$FUNCTION_APP_NAME" \
 #	--src "$ZIPFILE" 1>/dev/null
-$AZ functionapp deploy \
+az functionapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/function-app-managed-identity/python/scripts/test.sh
+++ b/samples/function-app-managed-identity/python/scripts/test.sh
@@ -8,20 +8,9 @@ INPUT_CONTAINER_NAME="input"
 OUTPUT_CONTAINER_NAME="output"
 STORAGE_ACCOUNT_NAME="${PREFIX}storage${SUFFIX}"
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Generate a timestamp in the format YYYY-MM-DD-HH-MM-SS
 TIMESTAMP=$(date +"%Y-%m-%d-%H-%M-%S")
 
@@ -34,7 +23,7 @@ FILE_EXTENSION="${FILE_NAME##*.}" # File extension
 BLOB_NAME="${FILE_BASE_NAME}-${TIMESTAMP}.${FILE_EXTENSION}"
 
 # Check whether the input container already exists
-CONTAINER_EXISTS=$($AZ storage container exists \
+CONTAINER_EXISTS=$(az storage container exists \
 	--name "$INPUT_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--auth-mode login | jq .exists)
@@ -45,14 +34,14 @@ else
 	echo "Container [$INPUT_CONTAINER_NAME] does not exist."
 
 	# Create the input container if it doesn't exist
-	$AZ storage container create \
+	az storage container create \
 		--name $INPUT_CONTAINER_NAME \
 		--account-name $STORAGE_ACCOUNT_NAME \
 		--auth-mode login
 fi
 
 # Check whether the output container already exists
-CONTAINER_EXISTS=$($AZ storage container exists \
+CONTAINER_EXISTS=$(az storage container exists \
 	--name "$OUTPUT_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--auth-mode login | jq .exists)
@@ -63,14 +52,14 @@ else
 	echo "Container [$OUTPUT_CONTAINER_NAME] does not exist."
 
 	# Create the output container if it doesn't exist
-	$AZ storage container create \
+	az storage container create \
 		--name $OUTPUT_CONTAINER_NAME \
 		--account-name $STORAGE_ACCOUNT_NAME \
 		--auth-mode login
 fi
 
 # Upload the file to the container
-$AZ storage blob upload \
+az storage blob upload \
 	--container-name $INPUT_CONTAINER_NAME \
 	--file "$FILE_PATH" \
 	--name "$BLOB_NAME" \
@@ -80,7 +69,7 @@ $AZ storage blob upload \
 echo "[$BLOB_NAME] file uploaded successfully to the [$INPUT_CONTAINER_NAME] container."
 
 # Verify the upload by checking if the blob exists in the input container
-BLOB_EXISTS=$($AZ storage blob exists \
+BLOB_EXISTS=$(az storage blob exists \
 	--container-name "$INPUT_CONTAINER_NAME" \
 	--name "$BLOB_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
@@ -102,7 +91,7 @@ seconds=5
 for ((i=1; i<=n; i++)); do
 	echo "Checking for [$BLOB_NAME] file in the [$OUTPUT_CONTAINER_NAME] container (Attempt $i of $n)..."
 	
-	BLOB_EXISTS=$($AZ storage blob exists \
+	BLOB_EXISTS=$(az storage blob exists \
 		--container-name "$OUTPUT_CONTAINER_NAME" \
 		--name "$BLOB_NAME" \
 		--account-name "$STORAGE_ACCOUNT_NAME" \

--- a/samples/function-app-managed-identity/python/scripts/user-managed-identity.sh
+++ b/samples/function-app-managed-identity/python/scripts/user-managed-identity.sh
@@ -16,31 +16,21 @@ ZIPFILE="function_app.zip"
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SUBSCRIPTION_ID=$(az account show --query id --output tsv)
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 RETRY_COUNT=3
 SLEEP=5
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -57,14 +47,14 @@ fi
 
 # Create a storage account
 echo "Checking if storage account [$STORAGE_ACCOUNT_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ storage account show \
+az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No storage account [$STORAGE_ACCOUNT_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating storage account [$STORAGE_ACCOUNT_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ storage account create \
+	az storage account create \
 		--name $STORAGE_ACCOUNT_NAME \
 		--location $LOCATION \
 		--resource-group $RESOURCE_GROUP_NAME \
@@ -82,7 +72,7 @@ fi
 
 # Get the storage account key
 echo "Getting storage account key for [$STORAGE_ACCOUNT_NAME]..."
-STORAGE_ACCOUNT_KEY=$($AZ storage account keys list \
+STORAGE_ACCOUNT_KEY=$(az storage account keys list \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "[0].value" \
@@ -100,7 +90,7 @@ STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=$STORAGE_A
 echo "Storage connection string constructed: [$STORAGE_CONNECTION_STRING]"
 
 # Get the storage account resource ID
-STORAGE_ACCOUNT_RESOURCE_ID=$($AZ storage account show \
+STORAGE_ACCOUNT_RESOURCE_ID=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "id" \
@@ -115,7 +105,7 @@ else
 fi
 
 # Get the storage account blob primary endpoint
-AZURE_STORAGE_ACCOUNT_URL=$($AZ storage account show \
+AZURE_STORAGE_ACCOUNT_URL=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "primaryEndpoints.blob" \
@@ -131,7 +121,7 @@ fi
 
 # Check if the input blob container exists
 echo "Checking if input blob container [$INPUT_STORAGE_CONTAINER_NAME] exists in the [$STORAGE_ACCOUNT_NAME] storage account..."
-$AZ storage container show \
+az storage container show \
 	--name "$INPUT_STORAGE_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--account-key "$STORAGE_ACCOUNT_KEY" &>/dev/null
@@ -140,7 +130,7 @@ if [[ $? != 0 ]]; then
 
 	# Create input blob container
 	echo "Creating input blob container [$INPUT_STORAGE_CONTAINER_NAME] in the [$STORAGE_ACCOUNT_NAME] storage account..."
-	$AZ storage container create \
+	az storage container create \
 		--name "$INPUT_STORAGE_CONTAINER_NAME" \
 		--account-name "$STORAGE_ACCOUNT_NAME" \
 		--account-key "$STORAGE_ACCOUNT_KEY"
@@ -155,7 +145,7 @@ fi
 
 # Check if the output blob container exists
 echo "Checking if output blob container [$OUTPUT_STORAGE_CONTAINER_NAME] exists in the [$STORAGE_ACCOUNT_NAME] storage account..."
-$AZ storage container show \
+az storage container show \
 	--name "$OUTPUT_STORAGE_CONTAINER_NAME" \
 	--account-name "$STORAGE_ACCOUNT_NAME" \
 	--account-key "$STORAGE_ACCOUNT_KEY" &>/dev/null
@@ -163,7 +153,7 @@ $AZ storage container show \
 if [[ $? != 0 ]]; then
 	# Create output blob container
 	echo "Creating output blob container [$OUTPUT_STORAGE_CONTAINER_NAME] in the [$STORAGE_ACCOUNT_NAME] storage account..."
-	$AZ storage container create \
+	az storage container create \
 		--name "$OUTPUT_STORAGE_CONTAINER_NAME" \
 		--account-name "$STORAGE_ACCOUNT_NAME" \
 		--account-key "$STORAGE_ACCOUNT_KEY"
@@ -179,7 +169,7 @@ fi
 # Check if the user-assigned managed identity already exists
 echo "Checking if [$MANAGED_IDENTITY_NAME] user-assigned managed identity actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
 
-$AZ identity show \
+az identity show \
 	--name"$MANAGED_IDENTITY_NAME" \
 	--resource-group $"$RESOURCE_GROUP_NAME" &>/dev/null
 
@@ -188,7 +178,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$MANAGED_IDENTITY_NAME] user-assigned managed identity in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the user-assigned managed identity
-	$AZ identity create \
+	az identity create \
 		--name "$MANAGED_IDENTITY_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -206,7 +196,7 @@ fi
 
 # Retrieve the clientId of the user-assigned managed identity
 echo "Retrieving clientId for [$MANAGED_IDENTITY_NAME] managed identity..."
-CLIENT_ID=$($AZ identity show \
+CLIENT_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query clientId \
@@ -221,7 +211,7 @@ fi
 
 # Retrieve the principalId of the user-assigned managed identity
 echo "Retrieving principalId for [$MANAGED_IDENTITY_NAME] managed identity..."
-PRINCIPAL_ID=$($AZ identity show \
+PRINCIPAL_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query principalId \
@@ -236,7 +226,7 @@ fi
 
 # Retrieve the resource id of the user-assigned managed identity
 echo "Retrieving resource id for the [$MANAGED_IDENTITY_NAME] managed identity..."
-IDENTITY_ID=$($AZ identity show \
+IDENTITY_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -251,7 +241,7 @@ fi
 
 # Create the function app
 echo "Creating function app [$FUNCTION_APP_NAME]..."
-$AZ functionapp create \
+az functionapp create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--consumption-plan-location $LOCATION \
 	--assign-identity "${IDENTITY_ID}" \
@@ -273,7 +263,7 @@ fi
 # Assign the Storage Blob Data Contributor role to the managed identity with the storage account as scope
 ROLE="Storage Blob Data Contributor"
 echo "Checking if the managed identity with principal ID [$PRINCIPAL_ID] has the [$ROLE] role assignment on storage account [$STORAGE_ACCOUNT_NAME]..."
-current=$($AZ role assignment list \
+current=$(az role assignment list \
 	--assignee "$PRINCIPAL_ID" \
 	--scope "$STORAGE_ACCOUNT_RESOURCE_ID" \
 	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
@@ -287,7 +277,7 @@ else
 	ATTEMPT=1
 	while [ $ATTEMPT -le $RETRY_COUNT ]; do
 		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
-		$AZ role assignment create \
+		az role assignment create \
 			--assignee "$PRINCIPAL_ID" \
 			--role "$ROLE" \
 			--scope "$STORAGE_ACCOUNT_RESOURCE_ID" 1>/dev/null
@@ -314,7 +304,7 @@ fi
 # Assign the Storage Queue Data Contributor role to the managed identity with the storage account as scope
 ROLE="Storage Queue Data Contributor"
 echo "Checking if the managed identity with principal ID [$PRINCIPAL_ID] has the [$ROLE] role assignment on storage account [$STORAGE_ACCOUNT_NAME]..."
-current=$($AZ role assignment list \
+current=$(az role assignment list \
 	--assignee "$PRINCIPAL_ID" \
 	--scope "$STORAGE_ACCOUNT_RESOURCE_ID" \
 	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
@@ -328,7 +318,7 @@ else
 	ATTEMPT=1
 	while [ $ATTEMPT -le $RETRY_COUNT ]; do
 		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
-		$AZ role assignment create \
+		az role assignment create \
 			--assignee "$PRINCIPAL_ID" \
 			--role "$ROLE" \
 			--scope "$STORAGE_ACCOUNT_RESOURCE_ID" 1>/dev/null
@@ -361,7 +351,7 @@ QUEUE_SERVICE_URI="https://${STORAGE_ACCOUNT_NAME}.queue.core.windows.net"
 TABLE_SERVICE_URI="https://${STORAGE_ACCOUNT_NAME}.table.core.windows.net"
 	
 
-$AZ functionapp config appsettings set \
+az functionapp config appsettings set \
 	--name $FUNCTION_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--settings \
@@ -399,7 +389,7 @@ zip -r "$ZIPFILE" function_app.py host.json requirements.txt
 
 # Deploy the function app
 echo "Deploying function app [$FUNCTION_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ functionapp deploy \
+az functionapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/function-app-managed-identity/python/scripts/validate.sh
+++ b/samples/function-app-managed-identity/python/scripts/validate.sh
@@ -1,41 +1,30 @@
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-managed-identity/python/terraform/README.md
+++ b/samples/function-app-managed-identity/python/terraform/README.md
@@ -118,41 +118,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/function-app-managed-identity/python/terraform/deploy.sh
@@ -7,19 +7,9 @@ LOCATION='westeurope'
 MANAGED_IDENTITY_TYPE='UserAssigned' # SystemAssigned or UserAssigned
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="function_app.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Run terraform init and apply
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
 
 echo "Initializing Terraform..."
 terraform init -upgrade
@@ -73,7 +63,7 @@ zip -r "$ZIPFILE" function_app.py host.json requirements.txt
 
 # Deploy the function app
 echo "Deploying function app [$FUNCTION_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ functionapp deploy \
+az functionapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/function-app-service-bus/dotnet/bicep/README.md
+++ b/samples/function-app-service-bus/dotnet/bicep/README.md
@@ -144,7 +144,6 @@ FUNCTION_APP_NAME="${PREFIX}-func-${SUFFIX}"
 SERVICE_BUS_NAMESPACE_NAME="${PREFIX}-service-bus-${SUFFIX}"
 STORAGE_ACCOUNT_NAME="${PREFIX}storage${SUFFIX}"
 APPLICATION_INSIGHTS_NAME="${PREFIX}-func-${SUFFIX}"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 PRIVATE_DNS_ZONE_NAMES=(
 	"privatelink.servicebus.windows.net"
 	"privatelink.blob.core.windows.net"
@@ -157,26 +156,16 @@ PE_NAMES=(
 	"${PREFIX}-queue-storage-pe-${SUFFIX}"
 	"${PREFIX}-table-storage-pe-${SUFFIX}"
 )
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -184,7 +173,7 @@ $AZ appservice plan show \
 
 # Check Azure Functions App
 echo -e "\n[$FUNCTION_APP_NAME] web app:\n"
-$AZ functionapp show \
+az functionapp show \
 	--name "$FUNCTION_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -192,7 +181,7 @@ $AZ functionapp show \
 
 # Check Service Bus Namespace
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
 	--name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -201,7 +190,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus Queues
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus queues:\n"
-$AZ servicebus queue list \
+az servicebus queue list \
 	--namespace-name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -210,7 +199,7 @@ $AZ servicebus queue list \
 
 	# Check Application Insights
 echo -e "\n[$APPLICATION_INSIGHTS_NAME] application insights:\n"
-$AZ monitor app-insights component show \
+az monitor app-insights component show \
 	--app "$APPLICATION_INSIGHTS_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -219,7 +208,7 @@ $AZ monitor app-insights component show \
 
 # Check Storage Account
 echo -e "\n[$STORAGE_ACCOUNT_NAME] storage account:\n"
-$AZ storage account show \
+az storage account show \
 	--name "$STORAGE_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:primaryLocation,ResourceGroup:resourceGroup}' \
@@ -228,7 +217,7 @@ $AZ storage account show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -237,7 +226,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -245,7 +234,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -254,7 +243,7 @@ $AZ network vnet show \
 # Check Private DNS Zone
 for PRIVATE_DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-	$AZ network private-dns zone show \
+	az network private-dns zone show \
 		--name "$PRIVATE_DNS_ZONE_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -265,7 +254,7 @@ done
 # Check Private Endpoint
 for PRIVATE_ENDPOINT_NAME in "${PE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-	$AZ network private-endpoint show \
+	az network private-endpoint show \
 		--name "$PRIVATE_ENDPOINT_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--output table \
@@ -274,7 +263,7 @@ done
 
 # Check Functions App Subnet NSG
 echo -e "\n[$FUNCTION_APP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$FUNCTION_APP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -282,7 +271,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -290,7 +279,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/function-app-service-bus/dotnet/bicep/deploy.sh
+++ b/samples/function-app-service-bus/dotnet/bicep/deploy.sh
@@ -12,30 +12,20 @@ USE_WHAT_IF=0
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="functionapp.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1> /dev/null
@@ -55,7 +45,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -73,7 +63,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -94,7 +84,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \
@@ -124,7 +114,7 @@ fi
 
 # Print the application settings of the function app
 echo "Retrieving application settings for function app [$FUNCTION_APP_NAME]..."
-$AZ functionapp config appsettings list \
+az functionapp config appsettings list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME"
 
@@ -153,7 +143,7 @@ cd ..
 
 # Deploy the function app
 echo "Deploying function app [$FUNCTION_APP_NAME] with zip file [$ZIPFILE]..."
-if $AZ functionapp deployment source config-zip \
+if az functionapp deployment source config-zip \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME" \
 	--src "$ZIPFILE" 1>/dev/null; then

--- a/samples/function-app-service-bus/dotnet/scripts/README.md
+++ b/samples/function-app-service-bus/dotnet/scripts/README.md
@@ -113,7 +113,6 @@ FUNCTION_APP_NAME="${PREFIX}-func-${SUFFIX}"
 SERVICE_BUS_NAMESPACE_NAME="${PREFIX}-service-bus-${SUFFIX}"
 STORAGE_ACCOUNT_NAME="${PREFIX}storage${SUFFIX}"
 APPLICATION_INSIGHTS_NAME="${PREFIX}-func-${SUFFIX}"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 PRIVATE_DNS_ZONE_NAMES=(
 	"privatelink.servicebus.windows.net"
 	"privatelink.blob.core.windows.net"
@@ -126,26 +125,16 @@ PE_NAMES=(
 	"${PREFIX}-queue-storage-pe-${SUFFIX}"
 	"${PREFIX}-table-storage-pe-${SUFFIX}"
 )
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -153,7 +142,7 @@ $AZ appservice plan show \
 
 # Check Azure Functions App
 echo -e "\n[$FUNCTION_APP_NAME] function app:\n"
-$AZ functionapp show \
+az functionapp show \
 	--name "$FUNCTION_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -161,7 +150,7 @@ $AZ functionapp show \
 
 # Check Service Bus Namespace
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
 	--name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -170,7 +159,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus Queues
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus queues:\n"
-$AZ servicebus queue list \
+az servicebus queue list \
 	--namespace-name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -179,7 +168,7 @@ $AZ servicebus queue list \
 
 	# Check Application Insights
 echo -e "\n[$APPLICATION_INSIGHTS_NAME] application insights:\n"
-$AZ monitor app-insights component show \
+az monitor app-insights component show \
 	--app "$APPLICATION_INSIGHTS_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -188,7 +177,7 @@ $AZ monitor app-insights component show \
 
 # Check Storage Account
 echo -e "\n[$STORAGE_ACCOUNT_NAME] storage account:\n"
-$AZ storage account show \
+az storage account show \
 	--name "$STORAGE_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:primaryLocation,ResourceGroup:resourceGroup}' \
@@ -197,7 +186,7 @@ $AZ storage account show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -206,7 +195,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -214,7 +203,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -223,7 +212,7 @@ $AZ network vnet show \
 # Check Private DNS Zone
 for PRIVATE_DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-	$AZ network private-dns zone show \
+	az network private-dns zone show \
 		--name "$PRIVATE_DNS_ZONE_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -234,7 +223,7 @@ done
 # Check Private Endpoint
 for PRIVATE_ENDPOINT_NAME in "${PE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-	$AZ network private-endpoint show \
+	az network private-endpoint show \
 		--name "$PRIVATE_ENDPOINT_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--output table \
@@ -243,7 +232,7 @@ done
 
 # Check Functions App Subnet NSG
 echo -e "\n[$FUNCTION_APP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$FUNCTION_APP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -251,7 +240,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -259,7 +248,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/function-app-service-bus/dotnet/scripts/call-http-trigger.sh
+++ b/samples/function-app-service-bus/dotnet/scripts/call-http-trigger.sh
@@ -68,7 +68,7 @@ get_docker_container_port_mapping() {
 call_http_trigger_function() {
 	# Get the function app name
 	echo "Getting function app name..."
-	function_app_name=$(azlocal functionapp list --query '[0].name' --output tsv)
+	function_app_name=$(az functionapp list --query '[0].name' --output tsv)
 
 	if [ -n "$function_app_name" ]; then
 		echo "Function app [$function_app_name] successfully retrieved."
@@ -79,7 +79,7 @@ call_http_trigger_function() {
 
 	# Get the resource group name
 	echo "Getting resource group name for function app [$function_app_name]..."
-	resource_group_name=$(azlocal functionapp list --query '[0].resourceGroup' --output tsv)
+	resource_group_name=$(az functionapp list --query '[0].resourceGroup' --output tsv)
 
 	if [ -n "$resource_group_name" ]; then
 		echo "Resource group [$resource_group_name] successfully retrieved."
@@ -90,7 +90,7 @@ call_http_trigger_function() {
 
 	# Get the the default host name of the function app
 	echo "Getting the default host name of the function app [$function_app_name]..."
-	function_host_name=$(azlocal functionapp show \
+	function_host_name=$(az functionapp show \
 		--name "$function_app_name" \
 		--resource-group "$resource_group_name" \
 		--query 'defaultHostName' \

--- a/samples/function-app-service-bus/dotnet/scripts/deploy.sh
+++ b/samples/function-app-service-bus/dotnet/scripts/deploy.sh
@@ -1,6 +1,6 @@
-WEBAP#!/bin/bash
+#!/bin/bash
 
-PREFIX='local'
+PREFIX='babo'
 SUFFIX='test'
 LOCATION='westeurope'
 RESOURCE_GROUP_NAME="${PREFIX}-rg"
@@ -31,9 +31,7 @@ SERVICE_BUS_CONNECTION_STRING=''
 INPUT_QUEUE_NAME="input"
 OUTPUT_QUEUE_NAME="output"
 TAGS='environment=test deployment=azcli'
-SUBSCRIPTION_ID=$(az account show --query id --output tsv)
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 DEPLOY=1
 RETRY_COUNT=3
 SLEEP=5
@@ -59,24 +57,15 @@ PE_DNS_ZONE_LABELS=("servicebus-zone" "blob-zone" "queue-zone" "table-zone")
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--tags $TAGS \
@@ -94,14 +83,14 @@ fi
 
 # Create a service bus namespace
 echo "Checking if [$SERVICE_BUS_NAMESPACE] service bus namespace exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ servicebus namespace show \
+az servicebus namespace show \
 	--name $SERVICE_BUS_NAMESPACE \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No [$SERVICE_BUS_NAMESPACE] service bus namespace exists in the [$RESOURCE_GROUP_NAME] resource group"
 	echo "Creating [$SERVICE_BUS_NAMESPACE] service bus namespace in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ servicebus namespace create \
+	az servicebus namespace create \
 		--name $SERVICE_BUS_NAMESPACE \
 		--sku Premium \
 		--location $LOCATION \
@@ -120,7 +109,7 @@ fi
 
 # Create the service bus input queue
 echo "Checking if [$INPUT_QUEUE_NAME] service bus queue exists in the [$SERVICE_BUS_NAMESPACE] service bus namespace..."
-$AZ servicebus queue show \
+az servicebus queue show \
 	--name $INPUT_QUEUE_NAME \
 	--namespace-name $SERVICE_BUS_NAMESPACE \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
@@ -129,7 +118,7 @@ if [[ $? != 0 ]]; then
 	echo "No [$INPUT_QUEUE_NAME] service bus queue exists in the [$SERVICE_BUS_NAMESPACE] service bus namespace"
 	echo "Creating [$INPUT_QUEUE_NAME] service bus queue in the [$SERVICE_BUS_NAMESPACE] service bus namespace..."
 
-	$AZ servicebus queue create \
+	az servicebus queue create \
 		--name $INPUT_QUEUE_NAME \
 		--namespace-name $SERVICE_BUS_NAMESPACE \
 		--resource-group $RESOURCE_GROUP_NAME 1>/dev/null
@@ -146,7 +135,7 @@ fi
 
 # Create the service bus output queue
 echo "Checking if [$OUTPUT_QUEUE_NAME] service bus queue exists in the [$SERVICE_BUS_NAMESPACE] service bus namespace..."
-$AZ servicebus queue show \
+az servicebus queue show \
 	--name $OUTPUT_QUEUE_NAME \
 	--namespace-name $SERVICE_BUS_NAMESPACE \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
@@ -155,7 +144,7 @@ if [[ $? != 0 ]]; then
 	echo "No [$OUTPUT_QUEUE_NAME] service bus queue exists in the [$SERVICE_BUS_NAMESPACE] service bus namespace"
 	echo "Creating [$OUTPUT_QUEUE_NAME] service bus queue in the [$SERVICE_BUS_NAMESPACE] service bus namespace..."
 
-	$AZ servicebus queue create \
+	az servicebus queue create \
 		--name $OUTPUT_QUEUE_NAME \
 		--namespace-name $SERVICE_BUS_NAMESPACE \
 		--resource-group $RESOURCE_GROUP_NAME 1>/dev/null
@@ -171,7 +160,7 @@ else
 fi
 
 # Retrieve and display connection string
-SERVICE_BUS_CONNECTION_STRING=$($AZ servicebus namespace authorization-rule keys list \
+SERVICE_BUS_CONNECTION_STRING=$(az servicebus namespace authorization-rule keys list \
 	--name RootManageSharedAccessKey \
 	--namespace-name $SERVICE_BUS_NAMESPACE \
 	--resource-group $RESOURCE_GROUP_NAME \
@@ -182,7 +171,7 @@ echo "Service Bus connection string: $SERVICE_BUS_CONNECTION_STRING"
 
 # Get the Service Bus namespace resource id
 echo "Getting [$SERVICE_BUS_NAMESPACE] service bus namespace resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-SERVICE_BUS_NAMESPACE_ID=$($AZ servicebus namespace show \
+SERVICE_BUS_NAMESPACE_ID=$(az servicebus namespace show \
 	--name $SERVICE_BUS_NAMESPACE \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query id \
@@ -197,21 +186,19 @@ fi
 
 # Check if the user-assigned managed identity already exists
 echo "Checking if [$MANAGED_IDENTITY_NAME] user-assigned managed identity actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-
-$AZ identity show \
-	--name"$MANAGED_IDENTITY_NAME" \
-	--resource-group $"$RESOURCE_GROUP_NAME" &>/dev/null
+az identity show \
+	--name "$MANAGED_IDENTITY_NAME" \
+	--resource-group "$RESOURCE_GROUP_NAME" &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No [$MANAGED_IDENTITY_NAME] user-assigned managed identity actually exists in the [$RESOURCE_GROUP_NAME] resource group"
 	echo "Creating [$MANAGED_IDENTITY_NAME] user-assigned managed identity in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the user-assigned managed identity
-	$AZ identity create \
+	az identity create \
 		--name "$MANAGED_IDENTITY_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
-		--subscription "$SUBSCRIPTION_ID" \
 		--tags $TAGS 1>/dev/null
 
 	if [[ $? == 0 ]]; then
@@ -226,7 +213,7 @@ fi
 
 # Retrieve the clientId of the user-assigned managed identity
 echo "Retrieving clientId for [$MANAGED_IDENTITY_NAME] managed identity..."
-CLIENT_ID=$($AZ identity show \
+CLIENT_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query clientId \
@@ -241,7 +228,7 @@ fi
 
 # Retrieve the principalId of the user-assigned managed identity
 echo "Retrieving principalId for [$MANAGED_IDENTITY_NAME] managed identity..."
-PRINCIPAL_ID=$($AZ identity show \
+PRINCIPAL_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query principalId \
@@ -256,7 +243,7 @@ fi
 
 # Retrieve the resource id of the user-assigned managed identity
 echo "Retrieving resource id for the [$MANAGED_IDENTITY_NAME] managed identity..."
-IDENTITY_ID=$($AZ identity show \
+IDENTITY_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -269,50 +256,9 @@ else
 	exit 1
 fi
 
-# Assign the Azure Service Bus Data Owner role to the managed identity with the Service Bus namespace as a scope
-ROLE="Azure Service Bus Data Owner"
-echo "Checking if the managed identity with principal ID [$PRINCIPAL_ID] has the [$ROLE] role assignment on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]..."
-current=$($AZ role assignment list \
-	--assignee "$PRINCIPAL_ID" \
-	--scope "$SERVICE_BUS_NAMESPACE_ID" \
-	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
-	--output tsv 2>/dev/null)
-
-if [[ $current == "$ROLE" ]]; then
-	echo "Managed identity already has the [$ROLE] role assignment on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
-else
-	echo "Managed identity does not have the [$ROLE] role assignment on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
-	echo "Creating role assignment: assigning [$ROLE] role to managed identity on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]..."
-	ATTEMPT=1
-	while [ $ATTEMPT -le $RETRY_COUNT ]; do
-		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
-		$AZ role assignment create \
-			--assignee "$PRINCIPAL_ID" \
-			--role "$ROLE" \
-			--scope "$SERVICE_BUS_NAMESPACE_ID" 1>/dev/null
-
-		if [[ $? == 0 ]]; then
-			break
-		else
-			if [ $ATTEMPT -lt $RETRY_COUNT ]; then
-				echo "Role assignment failed. Waiting [$SLEEP] seconds before retry..."
-				sleep $SLEEP
-			fi
-			ATTEMPT=$((ATTEMPT + 1))
-		fi
-	done
-
-	if [[ $? == 0 ]]; then
-		echo "Successfully assigned [$ROLE] role to managed identity on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
-	else
-		echo "Failed to assign [$ROLE] role to managed identity on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
-		exit
-	fi
-fi
-
 # Check if the network security group for the function app subnet already exists
 echo "Checking if [$FUNCTION_APP_SUBNET_NSG_NAME] network security group for the function app subnet actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network nsg show \
+az network nsg show \
 	--name "$FUNCTION_APP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -322,7 +268,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$FUNCTION_APP_SUBNET_NSG_NAME] network security group for the function app subnet..."
 
 	# Create the network security group for the function app subnet
-	$AZ network nsg create \
+	az network nsg create \
 		--name "$FUNCTION_APP_SUBNET_NSG_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -341,7 +287,7 @@ fi
 
 # Get the resource id of the network security group for the function app subnet
 echo "Getting [$FUNCTION_APP_SUBNET_NSG_NAME] network security group for the function app subnet resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-FUNCTION_APP_SUBNET_NSG_ID=$($AZ network nsg show \
+FUNCTION_APP_SUBNET_NSG_ID=$(az network nsg show \
 	--name "$FUNCTION_APP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -357,7 +303,7 @@ fi
 
 # Check if the network security group for the private endpoint subnet already exists
 echo "Checking if [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -367,7 +313,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet..."
 
 	# Create the network security group for the private endpoint subnet
-	$AZ network nsg create \
+	az network nsg create \
 		--name "$PE_SUBNET_NSG_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -386,7 +332,7 @@ fi
 
 # Get the resource id of the network security group for the private endpoint subnet
 echo "Getting [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-PE_SUBNET_NSG_ID=$($AZ network nsg show \
+PE_SUBNET_NSG_ID=$(az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -402,7 +348,7 @@ fi
 
 # Check if the public IP prefix for the NAT Gateway already exists
 echo "Checking if [$PIP_PREFIX_NAME] public IP prefix for the NAT Gateway actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network public-ip prefix show \
+az network public-ip prefix show \
 	--name "$PIP_PREFIX_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -412,7 +358,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$PIP_PREFIX_NAME] public IP prefix for the NAT Gateway in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the public IP prefix for the NAT Gateway
-	$AZ network public-ip prefix create \
+	az network public-ip prefix create \
 		--name "$PIP_PREFIX_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -432,7 +378,7 @@ fi
 
 # Check if the NAT Gateway already exists
 echo "Checking if [$NAT_GATEWAY_NAME] NAT Gateway actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -442,7 +388,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$NAT_GATEWAY_NAME] NAT Gateway in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the NAT Gateway
-	$AZ network nat gateway create \
+	az network nat gateway create \
 		--name "$NAT_GATEWAY_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -463,7 +409,7 @@ fi
 
 # Check if the virtual network already exists
 echo "Checking if [$VIRTUAL_NETWORK_NAME] virtual network actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -473,7 +419,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$VIRTUAL_NETWORK_NAME] virtual network in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the virtual network
-	$AZ network vnet create \
+	az network vnet create \
 		--name "$VIRTUAL_NETWORK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -494,7 +440,7 @@ if [[ $? != 0 ]]; then
 	echo "Associating [$FUNCTION_APP_SUBNET_NAME] subnet with the [$NAT_GATEWAY_NAME] NAT Gateway and the [$FUNCTION_APP_SUBNET_NSG_NAME] network security group..."
 
 	# Update the function app subnet to associate it with the NAT Gateway and the NSG
-	$AZ network vnet subnet update \
+	az network vnet subnet update \
 		--name "$FUNCTION_APP_SUBNET_NAME" \
 		--vnet-name "$VIRTUAL_NETWORK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
@@ -514,7 +460,7 @@ fi
 
 # Check if the subnet already exists
 echo "Checking if [$PE_SUBNET_NAME] subnet actually exists in the [$VIRTUAL_NETWORK_NAME] virtual network..."
-$AZ network vnet subnet show \
+az network vnet subnet show \
 	--name "$PE_SUBNET_NAME" \
 	--vnet-name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
@@ -525,7 +471,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$PE_SUBNET_NAME] subnet in the [$VIRTUAL_NETWORK_NAME] virtual network..."
 
 	# Create the subnet
-	$AZ network vnet subnet create \
+	az network vnet subnet create \
 		--name "$PE_SUBNET_NAME" \
 		--vnet-name "$VIRTUAL_NETWORK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
@@ -547,7 +493,7 @@ fi
 
 # Retrieve the virtual network resource id
 echo "Getting [$VIRTUAL_NETWORK_NAME] virtual network resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-VIRTUAL_NETWORK_ID=$($AZ network vnet show \
+VIRTUAL_NETWORK_ID=$(az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors \
@@ -565,7 +511,7 @@ fi
 for DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 	# Check if the private DNS Zone already exists
 	echo "Checking if [$DNS_ZONE_NAME] private DNS zone actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ network private-dns zone show \
+	az network private-dns zone show \
 		--name "$DNS_ZONE_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--only-show-errors &>/dev/null
@@ -575,7 +521,7 @@ for DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 		echo "Creating [$DNS_ZONE_NAME] private DNS zone in the [$RESOURCE_GROUP_NAME] resource group..."
 
 		# Create the private DNS Zone
-		$AZ network private-dns zone create \
+		az network private-dns zone create \
 			--name "$DNS_ZONE_NAME" \
 			--resource-group "$RESOURCE_GROUP_NAME" \
 			--tags $TAGS \
@@ -593,7 +539,7 @@ for DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 
 	# Check if the virtual network link already exists
 	echo "Checking if [$VIRTUAL_NETWORK_LINK_NAME] virtual network link between [$DNS_ZONE_NAME] private DNS zone and [$VIRTUAL_NETWORK_NAME] virtual network actually exists..."
-	$AZ network private-dns link vnet show \
+	az network private-dns link vnet show \
 		--name "$VIRTUAL_NETWORK_LINK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--zone-name "$DNS_ZONE_NAME" \
@@ -604,7 +550,7 @@ for DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 		echo "Creating [$VIRTUAL_NETWORK_LINK_NAME] virtual network link between [$DNS_ZONE_NAME] private DNS zone and [$VIRTUAL_NETWORK_NAME] virtual network..."
 
 		# Create the virtual network link
-		$AZ network private-dns link vnet create \
+		az network private-dns link vnet create \
 			--name "$VIRTUAL_NETWORK_LINK_NAME" \
 			--resource-group "$RESOURCE_GROUP_NAME" \
 			--zone-name "$DNS_ZONE_NAME" \
@@ -625,19 +571,20 @@ done
 
 # Create a storage account
 echo "Checking if storage account [$STORAGE_ACCOUNT_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ storage account show \
+az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No storage account [$STORAGE_ACCOUNT_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating storage account [$STORAGE_ACCOUNT_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ storage account create \
+	az storage account create \
 		--name $STORAGE_ACCOUNT_NAME \
 		--location $LOCATION \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--sku Standard_LRS \
-		--tags $TAGS 1>/dev/null
+		--tags $TAGS \
+		--only-show-errors 1>/dev/null
 
 	if [ $? -eq 0 ]; then
 		echo "Storage account [$STORAGE_ACCOUNT_NAME] created successfully in the [$RESOURCE_GROUP_NAME] resource group."
@@ -651,7 +598,7 @@ fi
 
 # Get the storage account key
 echo "Getting storage account key for [$STORAGE_ACCOUNT_NAME]..."
-STORAGE_ACCOUNT_KEY=$($AZ storage account keys list \
+STORAGE_ACCOUNT_KEY=$(az storage account keys list \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "[0].value" \
@@ -670,7 +617,7 @@ echo "Storage connection string constructed: [$STORAGE_CONNECTION_STRING]"
 
 # Get the storage account resource id
 echo "Getting [$STORAGE_ACCOUNT_NAME] storage account resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-STORAGE_ACCOUNT_ID=$($AZ storage account show \
+STORAGE_ACCOUNT_ID=$(az storage account show \
 	--name "$STORAGE_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -697,7 +644,7 @@ for i in "${!PE_NAMES[@]}"; do
 
 	# Check if the private endpoint already exists
 	echo "Checking if private endpoint [$PE_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group..."
-	privateEndpointId=$($AZ network private-endpoint list \
+	privateEndpointId=$(az network private-endpoint list \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--only-show-errors \
 		--query "[?name=='$PE_NAME'].id" \
@@ -708,7 +655,7 @@ for i in "${!PE_NAMES[@]}"; do
 		echo "Creating [$PE_NAME] private endpoint in the [$RESOURCE_GROUP_NAME] resource group..."
 
 		# Create the private endpoint
-		$AZ network private-endpoint create \
+		az network private-endpoint create \
 			--name "$PE_NAME" \
 			--resource-group "$RESOURCE_GROUP_NAME" \
 			--location "$LOCATION" \
@@ -732,20 +679,20 @@ for i in "${!PE_NAMES[@]}"; do
 
 	# Check if the private DNS zone group is already created
 	echo "Checking if the private DNS zone group [$PRIVATE_DNS_ZONE_GROUP_NAME] for the [$PE_NAME] private endpoint already exists..."
-	NAME=$($AZ network private-endpoint dns-zone-group show \
+	az network private-endpoint dns-zone-group show \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--endpoint-name "$PE_NAME" \
 		--name "$PRIVATE_DNS_ZONE_GROUP_NAME" \
 		--query name \
 		--output tsv \
-		--only-show-errors)
+		--only-show-errors &>/dev/null
 
-	if [[ -z $NAME ]]; then
+	if [[ $? != 0 ]]; then
 		echo "No private DNS zone group [$PRIVATE_DNS_ZONE_GROUP_NAME] for the [$PE_NAME] private endpoint actually exists"
 		echo "Creating private DNS zone group [$PRIVATE_DNS_ZONE_GROUP_NAME] for the [$PE_NAME] private endpoint..."
 
 		# Create the private DNS zone group
-		$AZ network private-endpoint dns-zone-group create \
+		az network private-endpoint dns-zone-group create \
 			--name "$PRIVATE_DNS_ZONE_GROUP_NAME" \
 			--resource-group "$RESOURCE_GROUP_NAME" \
 			--endpoint-name "$PE_NAME" \
@@ -771,7 +718,7 @@ fi
 
 # Check if the application insights component already exists
 echo "Checking if [$APPLICATION_INSIGHTS_NAME] Application Insights component exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ monitor app-insights component show \
+az monitor app-insights component show \
 	--app "$APPLICATION_INSIGHTS_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -781,7 +728,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$APPLICATION_INSIGHTS_NAME] Application Insights component in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the application insights component
-	$AZ monitor app-insights component create \
+	az monitor app-insights component create \
 		--app "$APPLICATION_INSIGHTS_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -799,14 +746,298 @@ else
 	echo "[$APPLICATION_INSIGHTS_NAME] Application Insights component already exists in the [$RESOURCE_GROUP_NAME] resource group."
 fi
 
+# Get the application insights component resource id
+echo "Getting [$APPLICATION_INSIGHTS_NAME] Application Insights component resource id in the [$RESOURCE_GROUP_NAME] resource group..."
+APPLICATION_INSIGHTS_ID=$(az monitor app-insights component show \
+	--app "$APPLICATION_INSIGHTS_NAME" \
+	--resource-group "$RESOURCE_GROUP_NAME" \
+	--query id \
+	--output tsv \
+	--only-show-errors)
+
+if [[ -n $APPLICATION_INSIGHTS_ID ]]; then
+	echo "[$APPLICATION_INSIGHTS_NAME] Application Insights component resource id retrieved successfully: $APPLICATION_INSIGHTS_ID"
+else
+	echo "Failed to retrieve [$APPLICATION_INSIGHTS_NAME] Application Insights component resource id in the [$RESOURCE_GROUP_NAME] resource group"
+	exit 1
+fi
+
+# Assign the Azure Service Bus Data Owner role to the managed identity with the Service Bus namespace as a scope
+ROLE="Azure Service Bus Data Owner"
+echo "Checking if the [$MANAGED_IDENTITY_NAME] managed identity has the [$ROLE] role assignment on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]..."
+current=$(az role assignment list \
+	--assignee "$PRINCIPAL_ID" \
+	--scope "$SERVICE_BUS_NAMESPACE_ID" \
+	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
+	--output tsv 2>/dev/null)
+
+if [[ $current == "$ROLE" ]]; then
+	echo "[$MANAGED_IDENTITY_NAME] managed identity already has the [$ROLE] role assignment on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
+else
+	echo "[$MANAGED_IDENTITY_NAME] managed identity does not have the [$ROLE] role assignment on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
+	echo "Creating role assignment: assigning [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]..."
+	ATTEMPT=1
+	while [ $ATTEMPT -le $RETRY_COUNT ]; do
+		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
+		az role assignment create \
+			--assignee "$PRINCIPAL_ID" \
+			--role "$ROLE" \
+			--scope "$SERVICE_BUS_NAMESPACE_ID" \
+			--only-show-errors 1>/dev/null
+
+		if [[ $? == 0 ]]; then
+			break
+		else
+			if [ $ATTEMPT -lt $RETRY_COUNT ]; then
+				echo "Role assignment failed. Waiting [$SLEEP] seconds before retry..."
+				sleep $SLEEP
+			fi
+			ATTEMPT=$((ATTEMPT + 1))
+		fi
+	done
+
+	if [[ $? == 0 ]]; then
+		echo "Successfully assigned [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
+	else
+		echo "Failed to assign [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the Service Bus namespace [$SERVICE_BUS_NAMESPACE]"
+		exit
+	fi
+fi
+
+# Get the storage account resource id for role assignments
+echo "Getting [$STORAGE_ACCOUNT_NAME] storage account resource id in the [$RESOURCE_GROUP_NAME] resource group..."
+STORAGE_ACCOUNT_ID=$(az storage account show \
+	--name "$STORAGE_ACCOUNT_NAME" \
+	--resource-group "$RESOURCE_GROUP_NAME" \
+	--query id \
+	--output tsv \
+	--only-show-errors)
+
+if [[ -n $STORAGE_ACCOUNT_ID ]]; then
+	echo "[$STORAGE_ACCOUNT_NAME] storage account resource id retrieved successfully"
+else
+	echo "Failed to retrieve [$STORAGE_ACCOUNT_NAME] storage account resource id in the [$RESOURCE_GROUP_NAME] resource group"
+	exit 1
+fi
+
+# Assign the Storage Account Contributor role to the managed identity with the storage account as a scope
+ROLE="Storage Account Contributor"
+echo "Checking if the [$MANAGED_IDENTITY_NAME] managed identity has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]..."
+current=$(az role assignment list \
+	--assignee "$PRINCIPAL_ID" \
+	--scope "$STORAGE_ACCOUNT_ID" \
+	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
+	--output tsv 2>/dev/null)
+
+if [[ $current == "$ROLE" ]]; then
+	echo "[$MANAGED_IDENTITY_NAME] managed identity already has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+else
+	echo "[$MANAGED_IDENTITY_NAME] managed identity does not have the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+	echo "Creating role assignment: assigning [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]..."
+	ATTEMPT=1
+	while [ $ATTEMPT -le $RETRY_COUNT ]; do
+		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
+		az role assignment create \
+			--assignee "$PRINCIPAL_ID" \
+			--role "$ROLE" \
+			--scope "$STORAGE_ACCOUNT_ID" \
+			--only-show-errors 1>/dev/null
+
+		if [[ $? == 0 ]]; then
+			break
+		else
+			if [ $ATTEMPT -lt $RETRY_COUNT ]; then
+				echo "Role assignment failed. Waiting [$SLEEP] seconds before retry..."
+				sleep $SLEEP
+			fi
+			ATTEMPT=$((ATTEMPT + 1))
+		fi
+	done
+
+	if [[ $? == 0 ]]; then
+		echo "Successfully assigned [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+	else
+		echo "Failed to assign [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+		exit
+	fi
+fi
+
+# Assign the Storage Blob Data Owner role to the managed identity with the storage account as a scope
+ROLE="Storage Blob Data Owner"
+echo "Checking if the [$MANAGED_IDENTITY_NAME] managed identity has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]..."
+current=$(az role assignment list \
+	--assignee "$PRINCIPAL_ID" \
+	--scope "$STORAGE_ACCOUNT_ID" \
+	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
+	--output tsv 2>/dev/null)
+
+if [[ $current == "$ROLE" ]]; then
+	echo "[$MANAGED_IDENTITY_NAME] managed identity already has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+else
+	echo "[$MANAGED_IDENTITY_NAME] managed identity does not have the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+	echo "Creating role assignment: assigning [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]..."
+	ATTEMPT=1
+	while [ $ATTEMPT -le $RETRY_COUNT ]; do
+		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
+		az role assignment create \
+			--assignee "$PRINCIPAL_ID" \
+			--role "$ROLE" \
+			--scope "$STORAGE_ACCOUNT_ID" \
+			--only-show-errors 1>/dev/null
+
+		if [[ $? == 0 ]]; then
+			break
+		else
+			if [ $ATTEMPT -lt $RETRY_COUNT ]; then
+				echo "Role assignment failed. Waiting [$SLEEP] seconds before retry..."
+				sleep $SLEEP
+			fi
+			ATTEMPT=$((ATTEMPT + 1))
+		fi
+	done
+
+	if [[ $? == 0 ]]; then
+		echo "Successfully assigned [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+	else
+		echo "Failed to assign [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+		exit
+	fi
+fi
+
+# Assign the Storage Queue Data Contributor role to the managed identity with the storage account as a scope
+ROLE="Storage Queue Data Contributor"
+echo "Checking if the [$MANAGED_IDENTITY_NAME] managed identity has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]..."
+current=$(az role assignment list \
+	--assignee "$PRINCIPAL_ID" \
+	--scope "$STORAGE_ACCOUNT_ID" \
+	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
+	--output tsv 2>/dev/null)
+
+if [[ $current == "$ROLE" ]]; then
+	echo "[$MANAGED_IDENTITY_NAME] managed identity already has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+else
+	echo "[$MANAGED_IDENTITY_NAME] managed identity does not have the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+	echo "Creating role assignment: assigning [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]..."
+	ATTEMPT=1
+	while [ $ATTEMPT -le $RETRY_COUNT ]; do
+		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
+		az role assignment create \
+			--assignee "$PRINCIPAL_ID" \
+			--role "$ROLE" \
+			--scope "$STORAGE_ACCOUNT_ID" \
+			--only-show-errors 1>/dev/null
+
+		if [[ $? == 0 ]]; then
+			break
+		else
+			if [ $ATTEMPT -lt $RETRY_COUNT ]; then
+				echo "Role assignment failed. Waiting [$SLEEP] seconds before retry..."
+				sleep $SLEEP
+			fi
+			ATTEMPT=$((ATTEMPT + 1))
+		fi
+	done
+
+	if [[ $? == 0 ]]; then
+		echo "Successfully assigned [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+	else
+		echo "Failed to assign [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+		exit
+	fi
+fi
+
+# Assign the Storage Table Data Contributor role to the managed identity with the storage account as a scope
+ROLE="Storage Table Data Contributor"
+echo "Checking if the [$MANAGED_IDENTITY_NAME] managed identity has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]..."
+current=$(az role assignment list \
+	--assignee "$PRINCIPAL_ID" \
+	--scope "$STORAGE_ACCOUNT_ID" \
+	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
+	--output tsv 2>/dev/null)
+
+if [[ $current == "$ROLE" ]]; then
+	echo "[$MANAGED_IDENTITY_NAME] managed identity already has the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+else
+	echo "[$MANAGED_IDENTITY_NAME] managed identity does not have the [$ROLE] role assignment on the storage account [$STORAGE_ACCOUNT_NAME]"
+	echo "Creating role assignment: assigning [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]..."
+	ATTEMPT=1
+	while [ $ATTEMPT -le $RETRY_COUNT ]; do
+		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
+		az role assignment create \
+			--assignee "$PRINCIPAL_ID" \
+			--role "$ROLE" \
+			--scope "$STORAGE_ACCOUNT_ID" \
+			--only-show-errors 1>/dev/null
+
+		if [[ $? == 0 ]]; then
+			break
+		else
+			if [ $ATTEMPT -lt $RETRY_COUNT ]; then
+				echo "Role assignment failed. Waiting [$SLEEP] seconds before retry..."
+				sleep $SLEEP
+			fi
+			ATTEMPT=$((ATTEMPT + 1))
+		fi
+	done
+
+	if [[ $? == 0 ]]; then
+		echo "Successfully assigned [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+	else
+		echo "Failed to assign [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the storage account [$STORAGE_ACCOUNT_NAME]"
+		exit
+	fi
+fi
+
+# Assign the Monitoring Metrics Publisher role to the managed identity with the Application Insights as a scope
+ROLE="Monitoring Metrics Publisher"
+echo "Checking if the [$MANAGED_IDENTITY_NAME] managed identity has the [$ROLE] role assignment on the Application Insights [$APPLICATION_INSIGHTS_NAME]..."
+current=$(az role assignment list \
+	--assignee "$PRINCIPAL_ID" \
+	--scope "$APPLICATION_INSIGHTS_ID" \
+	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
+	--output tsv 2>/dev/null)
+
+if [[ $current == "$ROLE" ]]; then
+	echo "[$MANAGED_IDENTITY_NAME] managed identity already has the [$ROLE] role assignment on the Application Insights [$APPLICATION_INSIGHTS_NAME]"
+else
+	echo "[$MANAGED_IDENTITY_NAME] managed identity does not have the [$ROLE] role assignment on the Application Insights [$APPLICATION_INSIGHTS_NAME]"
+	echo "Creating role assignment: assigning [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the Application Insights [$APPLICATION_INSIGHTS_NAME]..."
+	ATTEMPT=1
+	while [ $ATTEMPT -le $RETRY_COUNT ]; do
+		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
+		az role assignment create \
+			--assignee "$PRINCIPAL_ID" \
+			--role "$ROLE" \
+			--scope "$APPLICATION_INSIGHTS_ID" \
+			--only-show-errors 1>/dev/null
+
+		if [[ $? == 0 ]]; then
+			break
+		else
+			if [ $ATTEMPT -lt $RETRY_COUNT ]; then
+				echo "Role assignment failed. Waiting [$SLEEP] seconds before retry..."
+				sleep $SLEEP
+			fi
+			ATTEMPT=$((ATTEMPT + 1))
+		fi
+	done
+
+	if [[ $? == 0 ]]; then
+		echo "Successfully assigned [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the Application Insights [$APPLICATION_INSIGHTS_NAME]"
+	else
+		echo "Failed to assign [$ROLE] role to [$MANAGED_IDENTITY_NAME] managed identity on the Application Insights [$APPLICATION_INSIGHTS_NAME]"
+		exit
+	fi
+fi
+
 # Create the app service plan
 echo "Checking if app service plan [$APP_SERVICE_PLAN_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group..."
-if ! $AZ appservice plan show \
+if ! az appservice plan show \
 	--name $APP_SERVICE_PLAN_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null; then
 	echo "No app service plan [$APP_SERVICE_PLAN_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating app service plan [$APP_SERVICE_PLAN_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
-	if $AZ appservice plan create \
+	if az appservice plan create \
 		--name $APP_SERVICE_PLAN_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
@@ -825,7 +1056,7 @@ fi
 
 # Get the app service plan resource id
 echo "Getting [$APP_SERVICE_PLAN_NAME] app service plan resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-APP_SERVICE_PLAN_ID=$($AZ appservice plan show \
+APP_SERVICE_PLAN_ID=$(az appservice plan show \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -841,14 +1072,14 @@ fi
 
 # Check if the function app already exists
 echo "Checking if function app [$FUNCTION_APP_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group..."
-if ! $AZ functionapp show \
+if ! az functionapp show \
 	--name $FUNCTION_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null; then
 	echo "No function app [$FUNCTION_APP_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating function app [$FUNCTION_APP_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the function app
-	$AZ functionapp create \
+	az functionapp create \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--plan $APP_SERVICE_PLAN_NAME \
 		--assign-identity "$IDENTITY_ID" \
@@ -876,7 +1107,7 @@ fi
 
 # Get the function app resource id
 echo "Getting [$FUNCTION_APP_NAME] function app resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-FUNCTION_APP_ID=$($AZ functionapp show \
+FUNCTION_APP_ID=$(az functionapp show \
 	--name "$FUNCTION_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -893,7 +1124,7 @@ fi
 # Enable forced tunneling for the function app to route all outbound traffic through the virtual network and thus through the NAT Gateway
 echo "Enabling forced tunneling for function app [$FUNCTION_APP_NAME] to route all outbound traffic through the virtual network..."
 
-$AZ resource update \
+az resource update \
 	--ids "$FUNCTION_APP_ID" \
 	--set properties.outboundVnetRouting.allTraffic=true \
 	--only-show-errors 1>/dev/null
@@ -907,7 +1138,7 @@ fi
 
 # Set function app settings
 echo "Setting function app settings for [$FUNCTION_APP_NAME]..."
-$AZ functionapp config appsettings set \
+az functionapp config appsettings set \
 	--name $FUNCTION_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--settings \
@@ -920,7 +1151,8 @@ $AZ functionapp config appsettings set \
 	INPUT_QUEUE_NAME="input" \
 	OUTPUT_QUEUE_NAME="output" \
 	NAMES="Paolo,John,Jane,Max,Mary,Leo,Mia,Anna,Lisa,Anastasia" \
-	TIMER_SCHEDULE="*/10 * * * * *" 1>/dev/null
+	TIMER_SCHEDULE="*/10 * * * * *" \
+	--only-show-errors 1>/dev/null
 
 if [ $? -eq 0 ]; then
 	echo "Function app settings for [$FUNCTION_APP_NAME] set successfully."
@@ -931,7 +1163,7 @@ fi
 
 # Check if the log analytics workspace already exists
 echo "Checking if [$LOG_ANALYTICS_NAME] Log Analytics workspace already exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--only-show-errors &>/dev/null
@@ -941,7 +1173,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$LOG_ANALYTICS_NAME] Log Analytics workspace in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the Log Analytics workspace
-	$AZ monitor log-analytics workspace create \
+	az monitor log-analytics workspace create \
 		--name "$LOG_ANALYTICS_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -963,7 +1195,7 @@ fi
 
 # Check whether the diagnostic settings for the function app already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$FUNCTION_APP_NAME] function app already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$FUNCTION_APP_ID" \
 	--only-show-errors &>/dev/null
@@ -973,7 +1205,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$FUNCTION_APP_NAME] function app..."
 
 	# Create the diagnostic settings for the function app to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$FUNCTION_APP_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -998,7 +1230,7 @@ fi
 
 # Check whether the diagnostic settings for the app service plan already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$APP_SERVICE_PLAN_NAME] app service plan already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$APP_SERVICE_PLAN_ID" \
 	--only-show-errors &>/dev/null
@@ -1008,7 +1240,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$APP_SERVICE_PLAN_NAME] app service plan..."
 
 	# Create the diagnostic settings for the app service plan to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$APP_SERVICE_PLAN_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -1029,7 +1261,7 @@ fi
 
 # Check whether the diagnostic settings for the service bus namespace already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$SERVICE_BUS_NAMESPACE] service bus namespace already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$SERVICE_BUS_NAMESPACE_ID" \
 	--only-show-errors &>/dev/null
@@ -1039,7 +1271,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$SERVICE_BUS_NAMESPACE] service bus namespace..."
 
 	# Create the diagnostic settings for the service bus namespace to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$SERVICE_BUS_NAMESPACE_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -1066,7 +1298,7 @@ fi
 
 # Check whether the diagnostic settings for the virtual network already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$VIRTUAL_NETWORK_NAME] virtual network already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$VIRTUAL_NETWORK_ID" \
 	--only-show-errors &>/dev/null
@@ -1076,7 +1308,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$VIRTUAL_NETWORK_NAME] virtual network..."
 
 	# Create the diagnostic settings for the virtual network to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$VIRTUAL_NETWORK_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -1100,7 +1332,7 @@ fi
 
 # Check whether the diagnostic settings for the network security group for the function app subnet already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$FUNCTION_APP_SUBNET_NSG_NAME] network security group for the function app subnet already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$FUNCTION_APP_SUBNET_NSG_ID" \
 	--only-show-errors &>/dev/null
@@ -1110,7 +1342,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$FUNCTION_APP_SUBNET_NSG_NAME] network security group for the function app subnet..."
 
 	# Create the diagnostic settings for the network security group for the function app subnet to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$FUNCTION_APP_SUBNET_NSG_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -1132,7 +1364,7 @@ fi
 
 # Check whether the diagnostic settings for the network security group for the private endpoint subnet already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$PE_SUBNET_NSG_ID" \
 	--only-show-errors &>/dev/null
@@ -1142,7 +1374,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet..."
 
 	# Create the diagnostic settings for the network security group for the private endpoint subnet to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$PE_SUBNET_NSG_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -1187,10 +1419,11 @@ cd ..
 
 # Deploy the function app
 echo "Deploying function app [$FUNCTION_APP_NAME] with zip file [$ZIPFILE]..."
-if $AZ functionapp deployment source config-zip \
+if az functionapp deployment source config-zip \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME" \
-	--src "$ZIPFILE" 1>/dev/null; then
+	--src "$ZIPFILE" \
+	--only-show-errors 1>/dev/null; then
 	echo "Function app [$FUNCTION_APP_NAME] deployed successfully."
 else
 	echo "Failed to deploy function app [$FUNCTION_APP_NAME]."

--- a/samples/function-app-service-bus/dotnet/scripts/deploy.sh
+++ b/samples/function-app-service-bus/dotnet/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PREFIX='babo'
+PREFIX='local'
 SUFFIX='test'
 LOCATION='westeurope'
 RESOURCE_GROUP_NAME="${PREFIX}-rg"

--- a/samples/function-app-service-bus/dotnet/scripts/validate.sh
+++ b/samples/function-app-service-bus/dotnet/scripts/validate.sh
@@ -14,7 +14,6 @@ FUNCTION_APP_NAME="${PREFIX}-func-${SUFFIX}"
 SERVICE_BUS_NAMESPACE_NAME="${PREFIX}-service-bus-${SUFFIX}"
 STORAGE_ACCOUNT_NAME="${PREFIX}storage${SUFFIX}"
 APPLICATION_INSIGHTS_NAME="${PREFIX}-func-${SUFFIX}"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 PRIVATE_DNS_ZONE_NAMES=(
 	"privatelink.servicebus.windows.net"
 	"privatelink.blob.core.windows.net"
@@ -28,25 +27,16 @@ PE_NAMES=(
 	"${PREFIX}-table-storage-pe-${SUFFIX}"
 )
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -54,7 +44,7 @@ $AZ appservice plan show \
 
 # Check Azure Functions App
 echo -e "\n[$FUNCTION_APP_NAME] function app:\n"
-$AZ functionapp show \
+az functionapp show \
 	--name "$FUNCTION_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -62,7 +52,7 @@ $AZ functionapp show \
 
 # Check Service Bus Namespace
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
 	--name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -71,7 +61,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus Queues
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus queues:\n"
-$AZ servicebus queue list \
+az servicebus queue list \
 	--namespace-name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -80,7 +70,7 @@ $AZ servicebus queue list \
 
 	# Check Application Insights
 echo -e "\n[$APPLICATION_INSIGHTS_NAME] application insights:\n"
-$AZ monitor app-insights component show \
+az monitor app-insights component show \
 	--app "$APPLICATION_INSIGHTS_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -89,7 +79,7 @@ $AZ monitor app-insights component show \
 
 # Check Storage Account
 echo -e "\n[$STORAGE_ACCOUNT_NAME] storage account:\n"
-$AZ storage account show \
+az storage account show \
 	--name "$STORAGE_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:primaryLocation,ResourceGroup:resourceGroup}' \
@@ -98,7 +88,7 @@ $AZ storage account show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -107,7 +97,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -115,7 +105,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -124,7 +114,7 @@ $AZ network vnet show \
 # Check Private DNS Zone
 for PRIVATE_DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-	$AZ network private-dns zone show \
+	az network private-dns zone show \
 		--name "$PRIVATE_DNS_ZONE_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -135,7 +125,7 @@ done
 # Check Private Endpoint
 for PRIVATE_ENDPOINT_NAME in "${PE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-	$AZ network private-endpoint show \
+	az network private-endpoint show \
 		--name "$PRIVATE_ENDPOINT_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--output table \
@@ -144,7 +134,7 @@ done
 
 # Check Functions App Subnet NSG
 echo -e "\n[$FUNCTION_APP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$FUNCTION_APP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -152,7 +142,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -160,7 +150,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/function-app-service-bus/dotnet/terraform/README.md
+++ b/samples/function-app-service-bus/dotnet/terraform/README.md
@@ -149,7 +149,6 @@ FUNCTION_APP_NAME="${PREFIX}-func-${SUFFIX}"
 SERVICE_BUS_NAMESPACE_NAME="${PREFIX}-service-bus-${SUFFIX}"
 STORAGE_ACCOUNT_NAME="${PREFIX}storage${SUFFIX}"
 APPLICATION_INSIGHTS_NAME="${PREFIX}-func-${SUFFIX}"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 PRIVATE_DNS_ZONE_NAMES=(
 	"privatelink.servicebus.windows.net"
 	"privatelink.blob.core.windows.net"
@@ -162,26 +161,16 @@ PE_NAMES=(
 	"${PREFIX}-queue-storage-pe-${SUFFIX}"
 	"${PREFIX}-table-storage-pe-${SUFFIX}"
 )
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -189,7 +178,7 @@ $AZ appservice plan show \
 
 # Check Azure Functions App
 echo -e "\n[$FUNCTION_APP_NAME] function app:\n"
-$AZ functionapp show \
+az functionapp show \
 	--name "$FUNCTION_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -197,7 +186,7 @@ $AZ functionapp show \
 
 # Check Service Bus Namespace
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
 	--name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -206,7 +195,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus Queues
 echo -e "\n[$SERVICE_BUS_NAMESPACE_NAME] service bus queues:\n"
-$AZ servicebus queue list \
+az servicebus queue list \
 	--namespace-name "$SERVICE_BUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -215,7 +204,7 @@ $AZ servicebus queue list \
 
 	# Check Application Insights
 echo -e "\n[$APPLICATION_INSIGHTS_NAME] application insights:\n"
-$AZ monitor app-insights component show \
+az monitor app-insights component show \
 	--app "$APPLICATION_INSIGHTS_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -224,7 +213,7 @@ $AZ monitor app-insights component show \
 
 # Check Storage Account
 echo -e "\n[$STORAGE_ACCOUNT_NAME] storage account:\n"
-$AZ storage account show \
+az storage account show \
 	--name "$STORAGE_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:primaryLocation,ResourceGroup:resourceGroup}' \
@@ -233,7 +222,7 @@ $AZ storage account show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -242,7 +231,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -250,7 +239,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -259,7 +248,7 @@ $AZ network vnet show \
 # Check Private DNS Zone
 for PRIVATE_DNS_ZONE_NAME in "${PRIVATE_DNS_ZONE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-	$AZ network private-dns zone show \
+	az network private-dns zone show \
 		--name "$PRIVATE_DNS_ZONE_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -270,7 +259,7 @@ done
 # Check Private Endpoint
 for PRIVATE_ENDPOINT_NAME in "${PE_NAMES[@]}"; do
 	echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-	$AZ network private-endpoint show \
+	az network private-endpoint show \
 		--name "$PRIVATE_ENDPOINT_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--output table \
@@ -279,7 +268,7 @@ done
 
 # Check Functions App Subnet NSG
 echo -e "\n[$FUNCTION_APP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$FUNCTION_APP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -287,7 +276,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -295,7 +284,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/function-app-service-bus/dotnet/terraform/deploy.sh
+++ b/samples/function-app-service-bus/dotnet/terraform/deploy.sh
@@ -6,19 +6,9 @@ SUFFIX='test'
 LOCATION='westeurope'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="functionapp.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Run terraform init and apply
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
 
 # Intialize Terraform
 echo "Initializing Terraform..."
@@ -27,13 +17,13 @@ terraform init -upgrade
 # Run terraform plan and check for errors
 echo "Planning Terraform deployment..."
 terraform plan -out=tfplan \
-        -var "prefix=$PREFIX" \
-        -var "suffix=$SUFFIX" \
-        -var "location=$LOCATION"
+	-var "prefix=$PREFIX" \
+	-var "suffix=$SUFFIX" \
+	-var "location=$LOCATION"
 
 if [[ $? != 0 ]]; then
-        echo "Terraform plan failed. Exiting."
-        exit 1
+	echo "Terraform plan failed. Exiting."
+	exit 1
 fi
 
 # Apply the Terraform configuration
@@ -41,8 +31,8 @@ echo "Applying Terraform configuration..."
 terraform apply -auto-approve tfplan
 
 if [[ $? != 0 ]]; then
-        echo "Terraform apply failed. Exiting."
-        exit 1
+	echo "Terraform apply failed. Exiting."
+	exit 1
 fi
 
 # Get the output values
@@ -57,7 +47,7 @@ fi
 
 # Print the application settings of the function app
 echo "Retrieving application settings for function app [$FUNCTION_APP_NAME]..."
-$AZ functionapp config appsettings list \
+az functionapp config appsettings list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME"
 
@@ -86,7 +76,7 @@ cd ..
 
 # Deploy the function app
 echo "Deploying function app [$FUNCTION_APP_NAME] with zip file [$ZIPFILE]..."
-if $AZ functionapp deployment source config-zip \
+if az functionapp deployment source config-zip \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME" \
 	--src "$ZIPFILE" 1>/dev/null; then
@@ -103,4 +93,4 @@ fi
 
 # Print the list of resources in the resource group
 echo "Listing resources in resource group [$RESOURCE_GROUP_NAME]..."
-az resource list --resource-group "$RESOURCE_GROUP_NAME" --output table 
+az resource list --resource-group "$RESOURCE_GROUP_NAME" --output table

--- a/samples/function-app-storage-http/dotnet/bicep/README.md
+++ b/samples/function-app-storage-http/dotnet/bicep/README.md
@@ -95,53 +95,42 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage queues
-$AZ storage queue list \
+az storage queue list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage tables
-$AZ storage table list \
+az storage table list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-storage-http/dotnet/bicep/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/bicep/deploy.sh
@@ -11,30 +11,19 @@ SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="function_app.zip"
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create --name $RESOURCE_GROUP_NAME --location $LOCATION 1>/dev/null
+	az group create --name $RESOURCE_GROUP_NAME --location $LOCATION 1>/dev/null
 
 	if [[ $? == 0 ]]; then
 		echo "Resource group [$RESOURCE_GROUP_NAME] successfully created in the subscription [$SUBSCRIPTION_NAME]"
@@ -51,7 +40,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -67,7 +56,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -86,7 +75,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \
@@ -113,7 +102,7 @@ fi
 
 # Print the application settings of the function app
 echo "Retrieving application settings for function app [$FUNCTION_APP_NAME]..."
-$AZ webapp config appsettings list \
+az webapp config appsettings list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$FUNCTION_APP_NAME"
 
@@ -134,7 +123,7 @@ cd .. || exit
 
 # Deploy the function app using the zip file
 echo "Deploying function app [$FUNCTION_APP_NAME]..."
-$AZ functionapp deploy \
+az functionapp deploy \
     --resource-group "$RESOURCE_GROUP_NAME" \
     --name "$FUNCTION_APP_NAME" \
     --src-path $ZIPFILE \

--- a/samples/function-app-storage-http/dotnet/scripts/README.md
+++ b/samples/function-app-storage-http/dotnet/scripts/README.md
@@ -139,53 +139,42 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage queues
-$AZ storage queue list \
+az storage queue list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage tables
-$AZ storage table list \
+az storage table list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-storage-http/dotnet/scripts/call-http-triggers.sh
+++ b/samples/function-app-storage-http/dotnet/scripts/call-http-triggers.sh
@@ -68,7 +68,7 @@ get_docker_container_port_mapping() {
 call_http_trigger_functions() {
 	# Get the function app name
 	echo "Getting function app name..."
-	function_app_name=$(azlocal functionapp list --query '[0].name' --output tsv)
+	function_app_name=$(az functionapp list --query '[0].name' --output tsv)
 
 	if [ -n "$function_app_name" ]; then
 		echo "Function app [$function_app_name] successfully retrieved."
@@ -79,7 +79,7 @@ call_http_trigger_functions() {
 
 	# Get the resource group name
 	echo "Getting resource group name for function app [$function_app_name]..."
-	resource_group_name=$(azlocal functionapp list --query '[0].resourceGroup' --output tsv)
+	resource_group_name=$(az functionapp list --query '[0].resourceGroup' --output tsv)
 
 	if [ -n "$resource_group_name" ]; then
 		echo "Resource group [$resource_group_name] successfully retrieved."
@@ -90,7 +90,7 @@ call_http_trigger_functions() {
 
 	# Get the the default host name of the function app
 	echo "Getting the default host name of the function app [$function_app_name]..."
-	function_host_name=$(azlocal functionapp show \
+	function_host_name=$(az functionapp show \
 		--name "$function_app_name" \
 		--resource-group "$resource_group_name" \
 		--query 'defaultHostName' \

--- a/samples/function-app-storage-http/dotnet/scripts/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/scripts/deploy.sh
@@ -26,24 +26,22 @@ cd "$CURRENT_DIR" || exit
 
 # Choose the appropriate CLI based on the environment
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
+	echo "Using funclocal for LocalStack emulator environment."
 	FUNC="funclocal"
 else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
+	echo "Using standard func for AzureCloud environment."
 	FUNC="func"
 fi
 
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -60,14 +58,14 @@ fi
 
 # Create a storage account
 echo "Checking if storage account [$STORAGE_ACCOUNT_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ storage account show \
+az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No storage account [$STORAGE_ACCOUNT_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating storage account [$STORAGE_ACCOUNT_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ storage account create \
+	az storage account create \
 		--name $STORAGE_ACCOUNT_NAME \
 		--location $LOCATION \
 		--resource-group $RESOURCE_GROUP_NAME \
@@ -85,7 +83,7 @@ fi
 
 # Get the storage account key
 echo "Getting storage account key for [$STORAGE_ACCOUNT_NAME]..."
-STORAGE_ACCOUNT_KEY=$($AZ storage account keys list \
+STORAGE_ACCOUNT_KEY=$(az storage account keys list \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "[0].value" \
@@ -100,7 +98,7 @@ fi
 
 # Create the function app
 echo "Creating function app [$FUNCTION_APP_NAME]..."
-$AZ functionapp create \
+az functionapp create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--consumption-plan-location $LOCATION \
 	--runtime $RUNTIME \
@@ -122,7 +120,7 @@ STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=$STORAGE_A
 
 # Set function app settings
 echo "Setting function app settings for [$FUNCTION_APP_NAME]..."
-$AZ functionapp config appsettings set \
+az functionapp config appsettings set \
 	--name $FUNCTION_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--settings \

--- a/samples/function-app-storage-http/dotnet/scripts/validate.sh
+++ b/samples/function-app-storage-http/dotnet/scripts/validate.sh
@@ -1,53 +1,42 @@
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage queues
-$AZ storage queue list \
+az storage queue list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage tables
-$AZ storage table list \
+az storage table list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-storage-http/dotnet/terraform/README.md
+++ b/samples/function-app-storage-http/dotnet/terraform/README.md
@@ -113,53 +113,42 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
   --name local-rg \
   --output table
 
 # List resources
-$AZ resource list \
+az resource list \
   --resource-group local-rg \
   --output table
 
 # Check function app status
-$AZ functionapp show  \
+az functionapp show  \
   --name local-func-test \
   --resource-group local-rg \
   --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage queues
-$AZ storage queue list \
+az storage queue list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors
 
 # List storage tables
-$AZ storage table list \
+az storage table list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/function-app-storage-http/dotnet/terraform/deploy.sh
+++ b/samples/function-app-storage-http/dotnet/terraform/deploy.sh
@@ -1,24 +1,14 @@
 #!/bin/bash
 
 # Variables
-PREFIX='funchttp' #system or user
+PREFIX='local' #system or user
 SUFFIX='test'
 LOCATION='westeurope'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="function_app.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Run terraform init and apply
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
 
 echo "Initializing Terraform..."
 terraform init -upgrade
@@ -64,7 +54,7 @@ cd .. || exit
 
 # Deploy the function app using the zip file
 echo "Deploying function app [$FUNCTION_APP_NAME]..."
-if $AZ functionapp deploy \
+if az functionapp deploy \
     --resource-group "$RESOURCE_GROUP_NAME" \
     --name "$FUNCTION_APP_NAME" \
     --src-path $ZIPFILE \

--- a/samples/servicebus/java/bicep/README.md
+++ b/samples/servicebus/java/bicep/README.md
@@ -110,7 +110,6 @@ SUFFIX='test'
 RESOURCE_GROUP_NAME="${PREFIX}-rg"
 SERVICEBUS_NAMESPACE_NAME="${PREFIX}-sb-ns-${SUFFIX}"
 SERVICEBUS_QUEUE_NAME="myqueue"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Choose the appropriate CLI based on the environment
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -123,14 +122,14 @@ fi
 
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
   --name "$RESOURCE_GROUP_NAME" \
   --output table \
   --only-show-errors
 
 # Check Service Bus namespace
 echo -e "\n[$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --name "$SERVICEBUS_NAMESPACE_NAME" \
   --query "{name:name, location:location, serviceBusEndpoint:serviceBusEndpoint, status:provisioningState}" \
@@ -139,7 +138,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus queue
 echo -e "\n[$SERVICEBUS_QUEUE_NAME] Service Bus queue:\n"
-$AZ servicebus queue show \
+az servicebus queue show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
   --name "$SERVICEBUS_QUEUE_NAME" \

--- a/samples/servicebus/java/bicep/deploy.sh
+++ b/samples/servicebus/java/bicep/deploy.sh
@@ -12,30 +12,20 @@ VALIDATE_TEMPLATE=1
 USE_WHAT_IF=0
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1> /dev/null
@@ -55,7 +45,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -74,7 +64,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -96,7 +86,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \
@@ -126,7 +116,7 @@ fi
 
 # Retrieve the connection string for the Service Bus namespace
 echo "Retrieving connection string for [$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace..."
-AZURE_SERVICEBUS_CONNECTION_STRING=$($AZ servicebus namespace authorization-rule keys list \
+AZURE_SERVICEBUS_CONNECTION_STRING=$(az servicebus namespace authorization-rule keys list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
 	--name RootManageSharedAccessKey \
@@ -144,7 +134,3 @@ fi
 # Start the Java application
 echo "Starting Java application..."
 cd "$CURRENT_DIR/../app" && mvn clean spring-boot:run
-
-# Optionally tear down all resources (uncomment to enable)
-# echo "Deleting resource group [$RESOURCE_GROUP_NAME]..."
-# $AZ group delete --name "$RESOURCE_GROUP_NAME" --yes

--- a/samples/servicebus/java/scripts/README.md
+++ b/samples/servicebus/java/scripts/README.md
@@ -93,7 +93,6 @@ SUFFIX='test'
 RESOURCE_GROUP_NAME="${PREFIX}-rg"
 SERVICEBUS_NAMESPACE_NAME="${PREFIX}-sb-ns-${SUFFIX}"
 SERVICEBUS_QUEUE_NAME="myqueue"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Choose the appropriate CLI based on the environment
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -106,14 +105,14 @@ fi
 
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
   --name "$RESOURCE_GROUP_NAME" \
   --output table \
   --only-show-errors
 
 # Check Service Bus namespace
 echo -e "\n[$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --name "$SERVICEBUS_NAMESPACE_NAME" \
 	--query "{name:name, location:location, serviceBusEndpoint:serviceBusEndpoint, status:provisioningState}" \
@@ -122,7 +121,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus queue
 echo -e "\n[$SERVICEBUS_QUEUE_NAME] Service Bus queue:\n"
-$AZ servicebus queue show \
+az servicebus queue show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
   --name "$SERVICEBUS_QUEUE_NAME" \

--- a/samples/servicebus/java/scripts/deploy.sh
+++ b/samples/servicebus/java/scripts/deploy.sh
@@ -8,29 +8,19 @@ RESOURCE_GROUP_NAME="${PREFIX}-rg"
 SERVICEBUS_NAMESPACE_NAME="${PREFIX}-sb-ns-${SUFFIX}"
 SERVICEBUS_QUEUE_NAME="myqueue" # Queue name is hardcoded in the application properties
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check if the resource group already exists
 echo "Checking for resource group [$RESOURCE_GROUP_NAME]..."
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "Resource group [$RESOURCE_GROUP_NAME] not found. Creating..."
-	$AZ group create \
+	az group create \
 		--name "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
 		--only-show-errors 1>/dev/null
@@ -47,14 +37,14 @@ fi
 
 # Check if the Service Bus namespace already exists
 echo "Checking if [$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace already exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ servicebus namespace show \
+az servicebus namespace show \
 	--name "$SERVICEBUS_NAMESPACE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No [$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace found. Creating..."
-	$AZ servicebus namespace create \
+	az servicebus namespace create \
 		--name "$SERVICEBUS_NAMESPACE_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -72,7 +62,7 @@ fi
 
 # Check if the Service Bus queue already exists
 echo "Checking if [$SERVICEBUS_QUEUE_NAME] queue already exists in the [$SERVICEBUS_NAMESPACE_NAME] namespace..."
-$AZ servicebus queue show \
+az servicebus queue show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
 	--name "$SERVICEBUS_QUEUE_NAME" \
@@ -80,7 +70,7 @@ $AZ servicebus queue show \
 
 if [[ $? != 0 ]]; then
 	echo "No [$SERVICEBUS_QUEUE_NAME] queue found. Creating..."
-	$AZ servicebus queue create \
+	az servicebus queue create \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
 		--name "$SERVICEBUS_QUEUE_NAME" \
@@ -98,7 +88,7 @@ fi
 
 # Retrieve the connection string for the Service Bus namespace
 echo "Retrieving connection string for [$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace..."
-AZURE_SERVICEBUS_CONNECTION_STRING=$($AZ servicebus namespace authorization-rule keys list \
+AZURE_SERVICEBUS_CONNECTION_STRING=$(az servicebus namespace authorization-rule keys list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
 	--name RootManageSharedAccessKey \
@@ -119,4 +109,4 @@ cd "$CURRENT_DIR/../app" && mvn clean spring-boot:run
 
 # Optionally tear down all resources (uncomment to enable)
 # echo "Deleting resource group [$RESOURCE_GROUP_NAME]..."
-# $AZ group delete --name "$RESOURCE_GROUP_NAME" --yes
+# az group delete --name "$RESOURCE_GROUP_NAME" --yes

--- a/samples/servicebus/java/scripts/validate.sh
+++ b/samples/servicebus/java/scripts/validate.sh
@@ -6,27 +6,17 @@ SUFFIX='test'
 RESOURCE_GROUP_NAME="${PREFIX}-rg"
 SERVICEBUS_NAMESPACE_NAME="${PREFIX}-sb-ns-${SUFFIX}"
 SERVICEBUS_QUEUE_NAME="myqueue"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-  echo "Using azlocal for LocalStack emulator environment."
-  AZ="azlocal"
-else
-  echo "Using standard az for AzureCloud environment."
-  AZ="az"
-fi
 
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
   --name "$RESOURCE_GROUP_NAME" \
   --output table \
   --only-show-errors
 
 # Check Service Bus namespace
 echo -e "\n[$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --name "$SERVICEBUS_NAMESPACE_NAME" \
 	--query "{name:name, location:location, serviceBusEndpoint:serviceBusEndpoint, status:provisioningState}" \
@@ -35,7 +25,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus queue
 echo -e "\n[$SERVICEBUS_QUEUE_NAME] Service Bus queue:\n"
-$AZ servicebus queue show \
+az servicebus queue show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
   --name "$SERVICEBUS_QUEUE_NAME" \

--- a/samples/servicebus/java/terraform/README.md
+++ b/samples/servicebus/java/terraform/README.md
@@ -116,7 +116,6 @@ SUFFIX='test'
 RESOURCE_GROUP_NAME="${PREFIX}-rg"
 SERVICEBUS_NAMESPACE_NAME="${PREFIX}-sb-ns-${SUFFIX}"
 SERVICEBUS_QUEUE_NAME="myqueue"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Choose the appropriate CLI based on the environment
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
@@ -129,14 +128,14 @@ fi
 
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
   --name "$RESOURCE_GROUP_NAME" \
   --output table \
   --only-show-errors
 
 # Check Service Bus namespace
 echo -e "\n[$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace:\n"
-$AZ servicebus namespace show \
+az servicebus namespace show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --name "$SERVICEBUS_NAMESPACE_NAME" \
 	--query "{name:name, location:location, serviceBusEndpoint:serviceBusEndpoint, status:provisioningState}" \
@@ -145,7 +144,7 @@ $AZ servicebus namespace show \
 
 # Check Service Bus queue
 echo -e "\n[$SERVICEBUS_QUEUE_NAME] Service Bus queue:\n"
-$AZ servicebus queue show \
+az servicebus queue show \
   --resource-group "$RESOURCE_GROUP_NAME" \
   --namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
   --name "$SERVICEBUS_QUEUE_NAME" \

--- a/samples/servicebus/java/terraform/deploy.sh
+++ b/samples/servicebus/java/terraform/deploy.sh
@@ -6,20 +6,9 @@ SUFFIX='test'
 LOCATION='westeurope'
 SERVICEBUS_QUEUE_NAME="myqueue" # Queue name is hardcoded in the application properties
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Run terraform init and apply
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
 
 # Intialize Terraform
 echo "Initializing Terraform..."
@@ -59,7 +48,7 @@ fi
 
 # Retrieve the connection string for the Service Bus namespace
 echo "Retrieving connection string for [$SERVICEBUS_NAMESPACE_NAME] Service Bus namespace..."
-AZURE_SERVICEBUS_CONNECTION_STRING=$($AZ servicebus namespace authorization-rule keys list \
+AZURE_SERVICEBUS_CONNECTION_STRING=$(az servicebus namespace authorization-rule keys list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--namespace-name "$SERVICEBUS_NAMESPACE_NAME" \
 	--name RootManageSharedAccessKey \
@@ -78,6 +67,3 @@ fi
 echo "Starting Java application..."
 cd "$CURRENT_DIR/../app" && mvn clean spring-boot:run
 
-# Optionally tear down all resources (uncomment to enable)
-# echo "Deleting resource group [$RESOURCE_GROUP_NAME]..."
-# $AZ group delete --name "$RESOURCE_GROUP_NAME" --yes

--- a/samples/web-app-cosmosdb-mongodb-api/python/bicep/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/bicep/README.md
@@ -133,27 +133,16 @@ WEBAPP_NAME="${PREFIX}-webapp-${SUFFIX}"
 COSMOSDB_ACCOUNT_NAME="${PREFIX}-mongodb-${SUFFIX}"
 MONGODB_DATABASE_NAME="sampledb"
 COLLECTION_NAME="activities"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -161,7 +150,7 @@ $AZ appservice plan show \
 
 # Check Azure Web App
 echo -e "\n[$WEBAPP_NAME] web app:\n"
-$AZ webapp show \
+az webapp show \
 	--name "$WEBAPP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -169,7 +158,7 @@ $AZ webapp show \
 
 # Check Azure CosmosDB account
 echo -e "\n[$COSMOSDB_ACCOUNT_NAME] cosmosdb account:\n"
-$AZ cosmosdb show \
+az cosmosdb show \
 	--name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup,DocumentEndpoint:documentEndpoint}' \
@@ -178,7 +167,7 @@ $AZ cosmosdb show \
 
 # Check MongoDB database
 echo -e "\n[$MONGODB_DATABASE_NAME] mongodb database:\n"
-$AZ cosmosdb mongodb database show \
+az cosmosdb mongodb database show \
 	--name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
@@ -188,7 +177,7 @@ $AZ cosmosdb mongodb database show \
 
 # Check MongoDB collection
 echo -e "\n[$COLLECTION_NAME] mongodb collection:\n"
-$AZ cosmosdb mongodb collection show \
+az cosmosdb mongodb collection show \
 	--name "$COLLECTION_NAME" \
 	--database-name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
@@ -198,7 +187,7 @@ $AZ cosmosdb mongodb collection show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -207,7 +196,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -215,7 +204,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -223,7 +212,7 @@ $AZ network vnet show \
 
 # Check Private DNS Zone
 echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-$AZ network private-dns zone show \
+az network private-dns zone show \
 	--name "$PRIVATE_DNS_ZONE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -232,7 +221,7 @@ $AZ network private-dns zone show \
 
 # Check Private Endpoint
 echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-$AZ network private-endpoint show \
+az network private-endpoint show \
 	--name "$PRIVATE_ENDPOINT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -240,7 +229,7 @@ $AZ network private-endpoint show \
 
 # Check Web App Subnet NSG
 echo -e "\n[$WEBAPP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$WEBAPP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -248,7 +237,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -256,7 +245,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/web-app-cosmosdb-mongodb-api/python/bicep/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/bicep/deploy.sh
@@ -12,30 +12,20 @@ USE_WHAT_IF=0
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1> /dev/null
@@ -55,7 +45,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -73,7 +63,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -94,7 +84,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \
@@ -130,7 +120,7 @@ fi
 
 # Print the application settings of the web app
 echo "Retrieving application settings for web app [$WEB_APP_NAME]..."
-$AZ webapp config appsettings list \
+az webapp config appsettings list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME"
 
@@ -149,7 +139,7 @@ zip -r "$ZIPFILE" app.py mongodb.py static templates requirements.txt
 # Deploy the web app
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-cosmosdb-mongodb-api/python/scripts/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/scripts/README.md
@@ -118,27 +118,16 @@ WEBAPP_NAME="${PREFIX}-webapp-${SUFFIX}"
 COSMOSDB_ACCOUNT_NAME="${PREFIX}-mongodb-${SUFFIX}"
 MONGODB_DATABASE_NAME="sampledb"
 COLLECTION_NAME="activities"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -146,7 +135,7 @@ $AZ appservice plan show \
 
 # Check Azure Web App
 echo -e "\n[$WEBAPP_NAME] web app:\n"
-$AZ webapp show \
+az webapp show \
 	--name "$WEBAPP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -154,7 +143,7 @@ $AZ webapp show \
 
 # Check Azure CosmosDB account
 echo -e "\n[$COSMOSDB_ACCOUNT_NAME] cosmosdb account:\n"
-$AZ cosmosdb show \
+az cosmosdb show \
 	--name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup,DocumentEndpoint:documentEndpoint}' \
@@ -163,7 +152,7 @@ $AZ cosmosdb show \
 
 # Check MongoDB database
 echo -e "\n[$MONGODB_DATABASE_NAME] mongodb database:\n"
-$AZ cosmosdb mongodb database show \
+az cosmosdb mongodb database show \
 	--name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
@@ -173,7 +162,7 @@ $AZ cosmosdb mongodb database show \
 
 # Check MongoDB collection
 echo -e "\n[$COLLECTION_NAME] mongodb collection:\n"
-$AZ cosmosdb mongodb collection show \
+az cosmosdb mongodb collection show \
 	--name "$COLLECTION_NAME" \
 	--database-name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
@@ -183,7 +172,7 @@ $AZ cosmosdb mongodb collection show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -192,7 +181,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -200,7 +189,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -208,7 +197,7 @@ $AZ network vnet show \
 
 # Check Private DNS Zone
 echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-$AZ network private-dns zone show \
+az network private-dns zone show \
 	--name "$PRIVATE_DNS_ZONE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -217,7 +206,7 @@ $AZ network private-dns zone show \
 
 # Check Private Endpoint
 echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-$AZ network private-endpoint show \
+az network private-endpoint show \
 	--name "$PRIVATE_ENDPOINT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -225,7 +214,7 @@ $AZ network private-endpoint show \
 
 # Check Web App Subnet NSG
 echo -e "\n[$WEBAPP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$WEBAPP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -233,7 +222,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -241,7 +230,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/web-app-cosmosdb-mongodb-api/python/scripts/call-web-app.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/scripts/call-web-app.sh
@@ -68,7 +68,7 @@ get_docker_container_port_mapping() {
 call_web_app() {
 	# Get the web app name
 	echo "Getting web app name..."
-	web_app_name=$(azlocal webapp list --query '[0].name' --output tsv)
+	web_app_name=$(az webapp list --query '[0].name' --output tsv)
 
 	if [ -n "$web_app_name" ]; then
 		echo "Web app [$web_app_name] successfully retrieved."
@@ -79,7 +79,7 @@ call_web_app() {
 
 	# Get the resource group name
 	echo "Getting resource group name for web app [$web_app_name]..."
-	resource_group_name=$(azlocal webapp list --query '[0].resourceGroup' --output tsv)
+	resource_group_name=$(az webapp list --query '[0].resourceGroup' --output tsv)
 
 	if [ -n "$resource_group_name" ]; then
 		echo "Resource group [$resource_group_name] successfully retrieved."
@@ -90,7 +90,7 @@ call_web_app() {
 
 	# Get the the default host name of the web app
 	echo "Getting the default host name of the web app [$web_app_name]..."
-	app_host_name=$(azlocal webapp show \
+	app_host_name=$(az webapp show \
 		--name "$web_app_name" \
 		--resource-group "$resource_group_name" \
 		--query 'defaultHostName' \

--- a/samples/web-app-cosmosdb-mongodb-api/python/scripts/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/scripts/deploy.sh
@@ -38,23 +38,12 @@ LOGIN_NAME="paolo"
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
 SUBSCRIPTION_ID=$(az account show --query id --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Create a resource group
 echo "Creating resource group [$RESOURCE_GROUP_NAME]..."
-$AZ group create \
+az group create \
 	--name $RESOURCE_GROUP_NAME \
 	--location $LOCATION \
 	--only-show-errors 1>/dev/null
@@ -68,7 +57,7 @@ fi
 
 # Check if the CosmosDB account already exists
 echo "Checking if [$COSMOSDB_ACCOUNT_NAME] CosmosDB account already exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ cosmosdb show \
+az cosmosdb show \
 	--name $COSMOSDB_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors &>/dev/null
@@ -78,7 +67,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$COSMOSDB_ACCOUNT_NAME] CosmosDB account in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create a CosmosDB account with MongoDB kind
-	$AZ cosmosdb create \
+	az cosmosdb create \
 		--name $COSMOSDB_ACCOUNT_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--locations regionName=$LOCATION \
@@ -99,7 +88,7 @@ fi
 
 # Retrieve account resource id
 echo "Getting [$COSMOSDB_ACCOUNT_NAME] CosmosDB account resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-COSMOSDB_ACCOUNT_ID=$($AZ cosmosdb show \
+COSMOSDB_ACCOUNT_ID=$(az cosmosdb show \
 	--name $COSMOSDB_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query id \
@@ -115,7 +104,7 @@ fi
 
 # Retrieve document endpoint
 echo "Getting [$COSMOSDB_ACCOUNT_NAME] CosmosDB account document endpoint in the [$RESOURCE_GROUP_NAME] resource group..."
-DOCUMENT_ENDPOINT=$($AZ cosmosdb show \
+DOCUMENT_ENDPOINT=$(az cosmosdb show \
 	--name $COSMOSDB_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "documentEndpoint" \
@@ -131,7 +120,7 @@ fi
 
 # Check if the MongoDB database already exists
 echo "Checking if [$MONGODB_DATABASE_NAME] MongoDB database already exists in the [$COSMOSDB_ACCOUNT_NAME] CosmosDB account..."
-$AZ cosmosdb mongodb database show \
+az cosmosdb mongodb database show \
 	--account-name $COSMOSDB_ACCOUNT_NAME \
 	--name $MONGODB_DATABASE_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
@@ -142,7 +131,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$MONGODB_DATABASE_NAME] MongoDB database in the [$COSMOSDB_ACCOUNT_NAME] CosmosDB account..."
 
 	# Create MongoDB database in the CosmosDB account
-	$AZ cosmosdb mongodb database create \
+	az cosmosdb mongodb database create \
 		--account-name $COSMOSDB_ACCOUNT_NAME \
 		--name $MONGODB_DATABASE_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
@@ -161,7 +150,7 @@ fi
 
 # Check if the MongoDB database collection already exists
 echo "Checking if [$COLLECTION_NAME] collection already exists in the [$MONGODB_DATABASE_NAME] MongoDB database..."
-$AZ cosmosdb mongodb collection show \
+az cosmosdb mongodb collection show \
 	--account-name $COSMOSDB_ACCOUNT_NAME \
 	--database-name $MONGODB_DATABASE_NAME \
 	--name $COLLECTION_NAME \
@@ -173,7 +162,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$COLLECTION_NAME] collection in the [$MONGODB_DATABASE_NAME] MongoDB database..."
 
 	# Create a MongoDB database collection
-	$AZ cosmosdb mongodb collection create \
+	az cosmosdb mongodb collection create \
 		--account-name $COSMOSDB_ACCOUNT_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--database-name $MONGODB_DATABASE_NAME \
@@ -195,7 +184,7 @@ fi
 
 # List CosmosDB connection strings
 echo "Listing connection strings for CosmosDB account [$COSMOSDB_ACCOUNT_NAME]..."
-COSMOSDB_CONNECTION_STRING=$($AZ cosmosdb keys list \
+COSMOSDB_CONNECTION_STRING=$(az cosmosdb keys list \
 	--name $COSMOSDB_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--type connection-strings \
@@ -211,7 +200,7 @@ fi
 
 # Check if the network security group for the web app subnet already exists
 echo "Checking if [$WEBAPP_SUBNET_NSG_NAME] network security group for the web app subnet actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network nsg show \
+az network nsg show \
 	--name "$WEBAPP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -221,7 +210,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$WEBAPP_SUBNET_NSG_NAME] network security group for the web app subnet..."
 
 	# Create the network security group for the web app subnet
-	$AZ network nsg create \
+	az network nsg create \
 		--name "$WEBAPP_SUBNET_NSG_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -239,7 +228,7 @@ fi
 
 # Get the resource id of the network security group for the web app subnet
 echo "Getting [$WEBAPP_SUBNET_NSG_NAME] network security group for the web app subnet resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-WEBAPP_SUBNET_NSG_ID=$($AZ network nsg show \
+WEBAPP_SUBNET_NSG_ID=$(az network nsg show \
 	--name "$WEBAPP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -255,7 +244,7 @@ fi
 
 # Check if the network security group for the private endpoint subnet already exists
 echo "Checking if [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -265,7 +254,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet..."
 
 	# Create the network security group for the private endpoint subnet
-	$AZ network nsg create \
+	az network nsg create \
 		--name "$PE_SUBNET_NSG_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -283,7 +272,7 @@ fi
 
 # Get the resource id of the network security group for the private endpoint subnet
 echo "Getting [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-PE_SUBNET_NSG_ID=$($AZ network nsg show \
+PE_SUBNET_NSG_ID=$(az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -299,7 +288,7 @@ fi
 
 # Check if the public IP prefix for the NAT Gateway already exists
 echo "Checking if [$PIP_PREFIX_NAME] public IP prefix for the NAT Gateway actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network public-ip prefix show \
+az network public-ip prefix show \
 	--name "$PIP_PREFIX_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -309,7 +298,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$PIP_PREFIX_NAME] public IP prefix for the NAT Gateway in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the public IP prefix for the NAT Gateway
-	$AZ network public-ip prefix create \
+	az network public-ip prefix create \
 		--name "$PIP_PREFIX_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -328,7 +317,7 @@ fi
 
 # Check if the NAT Gateway already exists
 echo "Checking if [$NAT_GATEWAY_NAME] NAT Gateway actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -338,7 +327,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$NAT_GATEWAY_NAME] NAT Gateway in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the NAT Gateway
-	$AZ network nat gateway create \
+	az network nat gateway create \
 		--name "$NAT_GATEWAY_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -358,7 +347,7 @@ fi
 
 # Check if the virtual network already exists
 echo "Checking if [$VIRTUAL_NETWORK_NAME] virtual network actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -368,7 +357,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$VIRTUAL_NETWORK_NAME] virtual network in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the virtual network
-	$AZ network vnet create \
+	az network vnet create \
 		--name "$VIRTUAL_NETWORK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -388,7 +377,7 @@ if [[ $? != 0 ]]; then
 	echo "Associating [$WEBAPP_SUBNET_NAME] subnet with the [$NAT_GATEWAY_NAME] NAT Gateway and the [$WEBAPP_SUBNET_NSG_NAME] network security group..."
 
 	# Update the web app subnet to associate it with the NAT Gateway and the NSG
-	$AZ network vnet subnet update \
+	az network vnet subnet update \
 		--name "$WEBAPP_SUBNET_NAME" \
 		--vnet-name "$VIRTUAL_NETWORK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
@@ -408,7 +397,7 @@ fi
 
 # Check if the subnet already exists
 echo "Checking if [$PE_SUBNET_NAME] subnet actually exists in the [$VIRTUAL_NETWORK_NAME] virtual network..."
-$AZ network vnet subnet show \
+az network vnet subnet show \
 	--name "$PE_SUBNET_NAME" \
 	--vnet-name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
@@ -419,7 +408,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$PE_SUBNET_NAME] subnet in the [$VIRTUAL_NETWORK_NAME] virtual network..."
 
 	# Create the subnet
-	$AZ network vnet subnet create \
+	az network vnet subnet create \
 		--name "$PE_SUBNET_NAME" \
 		--vnet-name "$VIRTUAL_NETWORK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
@@ -441,7 +430,7 @@ fi
 
 # Retrieve the virtual network resource id
 echo "Getting [$VIRTUAL_NETWORK_NAME] virtual network resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-VIRTUAL_NETWORK_ID=$($AZ network vnet show \
+VIRTUAL_NETWORK_ID=$(az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors \
@@ -457,7 +446,7 @@ fi
 
 # Check if the private DNS Zone already exists
 echo "Checking if [$PRIVATE_DNS_ZONE_NAME] private DNS zone actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ network private-dns zone show \
+az network private-dns zone show \
 	--name "$PRIVATE_DNS_ZONE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors &>/dev/null
@@ -467,7 +456,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$PRIVATE_DNS_ZONE_NAME] private DNS zone in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the private DNS Zone
-	$AZ network private-dns zone create \
+	az network private-dns zone create \
 		--name "$PRIVATE_DNS_ZONE_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--only-show-errors 1>/dev/null
@@ -484,7 +473,7 @@ fi
 
 # Check if the virtual network link between the private DNS zone and the virtual network already exists
 echo "Checking if [$VIRTUAL_NETWORK_LINK_NAME] virtual network link between [$PRIVATE_DNS_ZONE_NAME] private DNS zone and [$VIRTUAL_NETWORK_NAME] virtual network actually exists..."
-$AZ network private-dns link vnet show \
+az network private-dns link vnet show \
 	--name "$VIRTUAL_NETWORK_LINK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--zone-name "$PRIVATE_DNS_ZONE_NAME" \
@@ -496,7 +485,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$VIRTUAL_NETWORK_LINK_NAME] virtual network link between [$PRIVATE_DNS_ZONE_NAME] private DNS zone and [$VIRTUAL_NETWORK_NAME] virtual network..."
 
 	# Create the virtual network link between [$PRIVATE_DNS_ZONE_NAME] private DNS zone and [$VIRTUAL_NETWORK_NAME] virtual network
-	$AZ network private-dns link vnet create \
+	az network private-dns link vnet create \
 		--name "$VIRTUAL_NETWORK_LINK_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--zone-name "$PRIVATE_DNS_ZONE_NAME" \
@@ -516,7 +505,7 @@ fi
 
 # Check if the private endpoint already exists
 echo "Checking if private endpoint [$PRIVATE_ENDPOINT_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group..."
-privateEndpointId=$($AZ network private-endpoint list \
+privateEndpointId=$(az network private-endpoint list \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--query "[?name=='$PRIVATE_ENDPOINT_NAME'].id" \
@@ -527,7 +516,7 @@ if [[ -z $privateEndpointId ]]; then
 	echo "Creating [$PRIVATE_ENDPOINT_NAME] private endpoint for the [$COSMOSDB_ACCOUNT_NAME] CosmosDB account in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create a private endpoint for the CosmosDB account
-	$AZ network private-endpoint create \
+	az network private-endpoint create \
 		--name "$PRIVATE_ENDPOINT_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -550,7 +539,7 @@ fi
 
 # Check if the private DNS zone grou is already created for the CosmosDB account private endpoint
 echo "Checking if the private DNS zone group [$PRIVATE_DNS_ZONE_GROUP_NAME] for the [$PRIVATE_ENDPOINT_NAME] private endpoint already exists..."
-NAME=$($AZ network private-endpoint dns-zone-group show \
+NAME=$(az network private-endpoint dns-zone-group show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--endpoint-name "$PRIVATE_ENDPOINT_NAME" \
 	--name "$PRIVATE_DNS_ZONE_GROUP_NAME" \
@@ -563,7 +552,7 @@ if [[ -z $NAME ]]; then
 	echo "Creating private DNS zone group [$PRIVATE_DNS_ZONE_GROUP_NAME] for the [$PRIVATE_ENDPOINT_NAME] private endpoint..."
 
 	# Create the private DNS zone group for the CosmosDB account private endpoint
-	$AZ network private-endpoint dns-zone-group create \
+	az network private-endpoint dns-zone-group create \
 		--name "$PRIVATE_DNS_ZONE_GROUP_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--endpoint-name "$PRIVATE_ENDPOINT_NAME" \
@@ -583,7 +572,7 @@ fi
 
 # Create app service plan
 echo "Creating app service plan [$APP_SERVICE_PLAN_NAME]..."
-$AZ appservice plan create \
+az appservice plan create \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--location "$LOCATION" \
@@ -600,7 +589,7 @@ fi
 
 # Get the app service plan resource id
 echo "Getting [$APP_SERVICE_PLAN_NAME] app service plan resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-APP_SERVICE_PLAN_ID=$($AZ appservice plan show \
+APP_SERVICE_PLAN_ID=$(az appservice plan show \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -616,7 +605,7 @@ fi
 
 # Create the web app
 echo "Creating web app [$WEBAPP_NAME]..."
-$AZ webapp create \
+az webapp create \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--plan "$APP_SERVICE_PLAN_NAME" \
 	--name "$WEBAPP_NAME" \
@@ -635,7 +624,7 @@ fi
 # Enabling
 echo "Enabling forced tunneling for web app [$WEBAPP_NAME] to route all outbound traffic through the virtual network..."
 
-$AZ resource update \
+az resource update \
 	--ids "/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.Web/sites/$WEBAPP_NAME" \
 	--set properties.outboundVnetRouting.allTraffic=true \
 	--only-show-errors 1>/dev/null
@@ -649,7 +638,7 @@ fi
 
 # Get the web app resource id
 echo "Getting [$WEBAPP_NAME] web app resource id in the [$RESOURCE_GROUP_NAME] resource group..."
-WEBAPP_ID=$($AZ webapp show \
+WEBAPP_ID=$(az webapp show \
 	--name "$WEBAPP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -665,7 +654,7 @@ fi
 
 # Set web app settings
 echo "Setting web app settings for [$WEBAPP_NAME]..."
-$AZ webapp config appsettings set \
+az webapp config appsettings set \
 	--name $WEBAPP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--settings \
@@ -687,7 +676,7 @@ fi
 
 # Check if the log analytics workspace already exists
 echo "Checking if [$LOG_ANALYTICS_NAME] Log Analytics workspace already exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--only-show-errors &>/dev/null
@@ -697,7 +686,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$LOG_ANALYTICS_NAME] Log Analytics workspace in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the Log Analytics workspace
-	$AZ monitor log-analytics workspace create \
+	az monitor log-analytics workspace create \
 		--name "$LOG_ANALYTICS_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -718,7 +707,7 @@ fi
 
 # Check whether the diagnostic settings for the web app already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$WEBAPP_NAME] web app already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$WEBAPP_ID" \
 	--only-show-errors &>/dev/null
@@ -728,7 +717,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$WEBAPP_NAME] web app..."
 
 	# Create the diagnostic settings for the web app to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$WEBAPP_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -759,7 +748,7 @@ fi
 
 # Check whether the diagnostic settings for the app service plan already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$APP_SERVICE_PLAN_NAME] app service plan already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$APP_SERVICE_PLAN_ID" \
 	--only-show-errors &>/dev/null
@@ -769,7 +758,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$APP_SERVICE_PLAN_NAME] app service plan..."
 
 	# Create the diagnostic settings for the app service plan to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$APP_SERVICE_PLAN_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -790,7 +779,7 @@ fi
 
 # Check whether the diagnostic settings for the CosmosDB account already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$COSMOSDB_ACCOUNT_NAME] CosmosDB account already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$COSMOSDB_ACCOUNT_ID" \
 	--only-show-errors &>/dev/null
@@ -800,7 +789,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$COSMOSDB_ACCOUNT_NAME] CosmosDB account..."
 
 	# Create the diagnostic settings for the CosmosDB account to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$COSMOSDB_ACCOUNT_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -825,7 +814,7 @@ fi
 
 # Check whether the diagnostic settings for the virtual network already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$VIRTUAL_NETWORK_NAME] virtual network already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$VIRTUAL_NETWORK_ID" \
 	--only-show-errors &>/dev/null
@@ -835,7 +824,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$VIRTUAL_NETWORK_NAME] virtual network..."
 
 	# Create the diagnostic settings for the virtual network to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$VIRTUAL_NETWORK_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -859,7 +848,7 @@ fi
 
 # Check whether the diagnostic settings for the network security group for the web app subnet already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$WEBAPP_SUBNET_NSG_NAME] network security group for the web app subnet already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$WEBAPP_SUBNET_NSG_ID" \
 	--only-show-errors &>/dev/null
@@ -869,7 +858,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$WEBAPP_SUBNET_NSG_NAME] network security group for the web app subnet..."
 
 	# Create the diagnostic settings for the network security group for the web app subnet to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$WEBAPP_SUBNET_NSG_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -891,7 +880,7 @@ fi
 
 # Check whether the diagnostic settings for the network security group for the private endpoint subnet already exist
 echo "Checking if [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet already exist..."
-$AZ monitor diagnostic-settings show \
+az monitor diagnostic-settings show \
 	--name "$DIAGNOSTIC_SETTINGS_NAME" \
 	--resource "$PE_SUBNET_NSG_ID" \
 	--only-show-errors &>/dev/null
@@ -901,7 +890,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$DIAGNOSTIC_SETTINGS_NAME] diagnostic settings for the [$PE_SUBNET_NSG_NAME] network security group for the private endpoint subnet..."
 
 	# Create the diagnostic settings for the network security group for the private endpoint subnet to send logs to the Log Analytics workspace
-	$AZ monitor diagnostic-settings create \
+	az monitor diagnostic-settings create \
 		--name "$DIAGNOSTIC_SETTINGS_NAME" \
 		--resource "$PE_SUBNET_NSG_ID" \
 		--workspace "$LOG_ANALYTICS_NAME" \
@@ -939,8 +928,8 @@ unzip -l "$ZIPFILE"
 
 # Deploy the web app
 echo "Deploying web app [$WEBAPP_NAME] with zip file [$ZIPFILE]..."
-echo "Using standard $AZ webapp deploy command for AzureCloud environment."
-$AZ webapp deploy \
+echo "Using standard az webapp deploy command for AzureCloud environment."
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEBAPP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-cosmosdb-mongodb-api/python/scripts/validate.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/scripts/validate.sh
@@ -16,27 +16,16 @@ WEBAPP_NAME="${PREFIX}-webapp-${SUFFIX}"
 COSMOSDB_ACCOUNT_NAME="${PREFIX}-mongodb-${SUFFIX}"
 MONGODB_DATABASE_NAME="sampledb"
 COLLECTION_NAME="activities"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -44,7 +33,7 @@ $AZ appservice plan show \
 
 # Check Azure Web App
 echo -e "\n[$WEBAPP_NAME] web app:\n"
-$AZ webapp show \
+az webapp show \
 	--name "$WEBAPP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -52,7 +41,7 @@ $AZ webapp show \
 
 # Check Azure CosmosDB account
 echo -e "\n[$COSMOSDB_ACCOUNT_NAME] cosmosdb account:\n"
-$AZ cosmosdb show \
+az cosmosdb show \
 	--name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup,DocumentEndpoint:documentEndpoint}' \
@@ -61,7 +50,7 @@ $AZ cosmosdb show \
 
 # Check MongoDB database
 echo -e "\n[$MONGODB_DATABASE_NAME] mongodb database:\n"
-$AZ cosmosdb mongodb database show \
+az cosmosdb mongodb database show \
 	--name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
@@ -71,7 +60,7 @@ $AZ cosmosdb mongodb database show \
 
 # Check MongoDB collection
 echo -e "\n[$COLLECTION_NAME] mongodb collection:\n"
-$AZ cosmosdb mongodb collection show \
+az cosmosdb mongodb collection show \
 	--name "$COLLECTION_NAME" \
 	--database-name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
@@ -81,7 +70,7 @@ $AZ cosmosdb mongodb collection show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -90,7 +79,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -98,7 +87,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -106,7 +95,7 @@ $AZ network vnet show \
 
 # Check Private DNS Zone
 echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-$AZ network private-dns zone show \
+az network private-dns zone show \
 	--name "$PRIVATE_DNS_ZONE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -115,7 +104,7 @@ $AZ network private-dns zone show \
 
 # Check Private Endpoint
 echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-$AZ network private-endpoint show \
+az network private-endpoint show \
 	--name "$PRIVATE_ENDPOINT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -123,7 +112,7 @@ $AZ network private-endpoint show \
 
 # Check Web App Subnet NSG
 echo -e "\n[$WEBAPP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$WEBAPP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -131,7 +120,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -139,7 +128,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/README.md
@@ -138,27 +138,16 @@ WEBAPP_NAME="${PREFIX}-webapp-${SUFFIX}"
 COSMOSDB_ACCOUNT_NAME="${PREFIX}-mongodb-${SUFFIX}"
 MONGODB_DATABASE_NAME="sampledb"
 COLLECTION_NAME="activities"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
 echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
-$AZ group show \
+az group show \
 	--name "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors
 
 # Check App Service Plan
 echo -e "\n[$APP_SERVICE_PLAN_NAME] app service plan:\n"
-$AZ appservice plan show \
+az appservice plan show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--output table \
@@ -166,7 +155,7 @@ $AZ appservice plan show \
 
 # Check Azure Web App
 echo -e "\n[$WEBAPP_NAME] web app:\n"
-$AZ webapp show \
+az webapp show \
 	--name "$WEBAPP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -174,7 +163,7 @@ $AZ webapp show \
 
 # Check Azure CosmosDB account
 echo -e "\n[$COSMOSDB_ACCOUNT_NAME] cosmosdb account:\n"
-$AZ cosmosdb show \
+az cosmosdb show \
 	--name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup,DocumentEndpoint:documentEndpoint}' \
@@ -183,7 +172,7 @@ $AZ cosmosdb show \
 
 # Check MongoDB database
 echo -e "\n[$MONGODB_DATABASE_NAME] mongodb database:\n"
-$AZ cosmosdb mongodb database show \
+az cosmosdb mongodb database show \
 	--name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
@@ -193,7 +182,7 @@ $AZ cosmosdb mongodb database show \
 
 # Check MongoDB collection
 echo -e "\n[$COLLECTION_NAME] mongodb collection:\n"
-$AZ cosmosdb mongodb collection show \
+az cosmosdb mongodb collection show \
 	--name "$COLLECTION_NAME" \
 	--database-name "$MONGODB_DATABASE_NAME" \
 	--account-name "$COSMOSDB_ACCOUNT_NAME" \
@@ -203,7 +192,7 @@ $AZ cosmosdb mongodb collection show \
 
 # Check Log Analytics Workspace
 echo -e "\n[$LOG_ANALYTICS_NAME] log analytics workspace:\n"
-$AZ monitor log-analytics workspace show \
+az monitor log-analytics workspace show \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--workspace-name "$LOG_ANALYTICS_NAME" \
 	--query '{Name:name,Location:location,ResourceGroup:resourceGroup}' \
@@ -212,7 +201,7 @@ $AZ monitor log-analytics workspace show \
 
 # Check NAT Gateway
 echo -e "\n[$NAT_GATEWAY_NAME] nat gateway:\n"
-$AZ network nat gateway show \
+az network nat gateway show \
 	--name "$NAT_GATEWAY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -220,7 +209,7 @@ $AZ network nat gateway show \
 
 # Check Virtual Network
 echo -e "\n[$VIRTUAL_NETWORK_NAME] virtual network:\n"
-$AZ network vnet show \
+az network vnet show \
 	--name "$VIRTUAL_NETWORK_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -228,7 +217,7 @@ $AZ network vnet show \
 
 # Check Private DNS Zone
 echo -e "\n[$PRIVATE_DNS_ZONE_NAME] private dns zone:\n"
-$AZ network private-dns zone show \
+az network private-dns zone show \
 	--name "$PRIVATE_DNS_ZONE_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query '{Name:name,ResourceGroup:resourceGroup,RecordSets:recordSets,VirtualNetworkLinks:virtualNetworkLinks}' \
@@ -237,7 +226,7 @@ $AZ network private-dns zone show \
 
 # Check Private Endpoint
 echo -e "\n[$PRIVATE_ENDPOINT_NAME] private endpoint:\n"
-$AZ network private-endpoint show \
+az network private-endpoint show \
 	--name "$PRIVATE_ENDPOINT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -245,7 +234,7 @@ $AZ network private-endpoint show \
 
 # Check Web App Subnet NSG
 echo -e "\n[$WEBAPP_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$WEBAPP_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -253,7 +242,7 @@ $AZ network nsg show \
 
 # Check Private Endpoint Subnet NSG
 echo -e "\n[$PE_SUBNET_NSG_NAME] network security group:\n"
-$AZ network nsg show \
+az network nsg show \
 	--name "$PE_SUBNET_NSG_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
@@ -261,7 +250,7 @@ $AZ network nsg show \
 
 # List resources
 echo -e "\n[$RESOURCE_GROUP_NAME] all resources:\n"
-$AZ resource list \
+az resource list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--output table \
 	--only-show-errors

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/deploy.sh
@@ -6,19 +6,9 @@ SUFFIX='test'
 LOCATION='westeurope'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Run terraform init and apply
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
 
 # Intialize Terraform
 echo "Initializing Terraform..."
@@ -57,7 +47,7 @@ fi
 
 # Print the application settings of the web app
 echo "Retrieving application settings for web app [$WEB_APP_NAME]..."
-$AZ webapp config appsettings list \
+az webapp config appsettings list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME"
 
@@ -76,7 +66,7 @@ zip -r "$ZIPFILE" app.py mongodb.py static templates requirements.txt
 # Deploy the web app
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-cosmosdb-nosql-api/python/scripts/README.md
+++ b/samples/web-app-cosmosdb-nosql-api/python/scripts/README.md
@@ -65,35 +65,24 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-nosql-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure CosmosDB account
-$AZ cosmosdb show \
+az cosmosdb show \
 --name local-webapp-nosql-test \
 --resource-group local-rg \
 --output table

--- a/samples/web-app-cosmosdb-nosql-api/python/scripts/validate.sh
+++ b/samples/web-app-cosmosdb-nosql-api/python/scripts/validate.sh
@@ -1,48 +1,37 @@
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-nosql-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure CosmosDB account
-$AZ cosmosdb show \
+az cosmosdb show \
 --name local-webapp-nosql-test \
 --resource-group local-rg \
 --output table
 
 # Check database (not implemented yet)
-# $AZ database show \
+# az database show \
 # --name sampledb \
 # --account-name local-webapp-nosqltest \
 # --resource-group local-rg \
 # --output table
 
 # Check collection (not impleented yet)
-# $AZ cosmosdb collection show \
+# az cosmosdb collection show \
 # --name activities \
 # --database-name sampledb \
 # --account-name local-webapp-nosql-test \

--- a/samples/web-app-managed-identity/python/bicep/README.md
+++ b/samples/web-app-managed-identity/python/bicep/README.md
@@ -93,41 +93,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/web-app-managed-identity/python/bicep/deploy.sh
+++ b/samples/web-app-managed-identity/python/bicep/deploy.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Enable verbose debugging
-set -x
-
 # Variables
 PREFIX='local'
 SUFFIX='test'
@@ -16,37 +13,20 @@ SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="webapp_app.zip"
 MANAGED_IDENTITY_TYPE="UserAssigned" # SystemAssigned or UserAssigned
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-echo "=================================================="
-echo "DEBUG: Starting bicep deployment for web-app-managed-identity"
-echo "DEBUG: Resource Group: $RESOURCE_GROUP_NAME"
-echo "DEBUG: Environment: $ENVIRONMENT"
-echo "DEBUG: Managed Identity Type: $MANAGED_IDENTITY_TYPE"
-echo "=================================================="
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -66,7 +46,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -85,7 +65,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -107,7 +87,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \
@@ -153,7 +133,7 @@ zip -r "$ZIPFILE" app.py requirements.txt static templates
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-managed-identity/python/scripts/README.md
+++ b/samples/web-app-managed-identity/python/scripts/README.md
@@ -109,41 +109,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/web-app-managed-identity/python/scripts/api.sh
+++ b/samples/web-app-managed-identity/python/scripts/api.sh
@@ -10,33 +10,29 @@ MANAGED_IDENTITY_NAME="${PREFIX}-identity-${SUFFIX}-${RANDOM_SUFFIX}"
 RESOURCE_GROUP_NAME="${PREFIX}-rg"
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 SUBSCRIPTION_ID=$(az account show --query id --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 PROXY_PORT=$(curl http://localhost:4566/_localstack/proxy -s | jq '.proxy_port')
 SUB_BASE_URL="https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/providers/Microsoft.ManagedIdentity/userAssignedIdentities"
 RG_BASE_URL="https://management.azure.com/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP_NAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities"
+ENVIRONMENT=$(az account show --query environmentName --output tsv)
 API_VERSION="2024-11-30"
 
 # Choose the appropriate CLI based on the environment
 if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
 	CURL="env http_proxy=http://127.0.0.1:$PROXY_PORT https_proxy=http://127.0.0.1:$PROXY_PORT curl -k -s"
 else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
 	CURL="curl -s"
 fi
 
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location "$LOCATION" \
 		--only-show-errors 1>/dev/null
@@ -52,7 +48,7 @@ else
 fi
 
 # Get security token
-TOKEN=$($AZ account get-access-token --resource=https://management.azure.com/ --query accessToken --output tsv)
+TOKEN=$(az account get-access-token --resource=https://management.azure.com/ --query accessToken --output tsv)
 
 # Create a new user-assigned managed identity
 echo "Creating user-assigned managed identity [$MANAGED_IDENTITY_NAME]..."

--- a/samples/web-app-managed-identity/python/scripts/call-web-app.sh
+++ b/samples/web-app-managed-identity/python/scripts/call-web-app.sh
@@ -68,7 +68,7 @@ get_docker_container_port_mapping() {
 call_web_app() {
 	# Get the web app name
 	echo "Getting web app name..."
-	web_app_name=$(azlocal webapp list --query '[0].name' --output tsv)
+	web_app_name=$(az webapp list --query '[0].name' --output tsv)
 
 	if [ -n "$web_app_name" ]; then
 		echo "Web app [$web_app_name] successfully retrieved."
@@ -79,7 +79,7 @@ call_web_app() {
 
 	# Get the resource group name
 	echo "Getting resource group name for web app [$web_app_name]..."
-	resource_group_name=$(azlocal webapp list --query '[0].resourceGroup' --output tsv)
+	resource_group_name=$(az webapp list --query '[0].resourceGroup' --output tsv)
 
 	if [ -n "$resource_group_name" ]; then
 		echo "Resource group [$resource_group_name] successfully retrieved."
@@ -90,7 +90,7 @@ call_web_app() {
 
 	# Get the the default host name of the web app
 	echo "Getting the default host name of the web app [$web_app_name]..."
-	app_host_name=$(azlocal webapp show \
+	app_host_name=$(az webapp show \
 		--name "$web_app_name" \
 		--resource-group "$resource_group_name" \
 		--query 'defaultHostName' \

--- a/samples/web-app-managed-identity/python/scripts/cli.sh
+++ b/samples/web-app-managed-identity/python/scripts/cli.sh
@@ -8,27 +8,17 @@ RANDOM_SUFFIX=$(head /dev/urandom | tr -dc 'a-z0-9' | head -c 4)
 MANAGED_IDENTITY_NAME="${PREFIX}-identity-${SUFFIX}-${RANDOM_SUFFIX}"
 RESOURCE_GROUP_NAME="${PREFIX}-rg"
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
 
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location "$LOCATION" \
 		--only-show-errors 1>/dev/null
@@ -45,7 +35,7 @@ fi
 
 # Create a new user-assigned managed identity
 echo "Creating user-assigned managed identity [$MANAGED_IDENTITY_NAME]..."
-$AZ identity create \
+az identity create \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--location "$LOCATION" \
@@ -61,7 +51,7 @@ fi
 
 # Get the user-assigned managed identity
 echo "Retrieving user-assigned managed identity [$MANAGED_IDENTITY_NAME]..."
-$AZ identity show \
+az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors
@@ -75,7 +65,7 @@ fi
 
 # List all user-assigned managed identities in the resource group
 echo "Listing all user-assigned managed identities in resource group [$RESOURCE_GROUP_NAME]..."
-$AZ identity list \
+az identity list \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors
 
@@ -88,7 +78,7 @@ fi
 
 # Delete the user-assigned managed identity
 echo "Deleting user-assigned managed identity [$MANAGED_IDENTITY_NAME]..."
-$AZ identity delete \
+az identity delete \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--only-show-errors

--- a/samples/web-app-managed-identity/python/scripts/system-assigned.sh
+++ b/samples/web-app-managed-identity/python/scripts/system-assigned.sh
@@ -14,7 +14,6 @@ RUNTIME_VERSION="3.13"
 CONTAINER_NAME='activities'
 ZIPFILE="webapp_app.zip"
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RETRY_COUNT=3
 SLEEP=5
@@ -22,25 +21,16 @@ SLEEP=5
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -57,14 +47,14 @@ fi
 
 # Create a storage account
 echo "Checking if storage account [$STORAGE_ACCOUNT_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ storage account show \
+az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No storage account [$STORAGE_ACCOUNT_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating storage account [$STORAGE_ACCOUNT_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ storage account create \
+	az storage account create \
 		--name $STORAGE_ACCOUNT_NAME \
 		--location $LOCATION \
 		--resource-group $RESOURCE_GROUP_NAME \
@@ -82,7 +72,7 @@ fi
 
 # Get the storage account key
 echo "Getting storage account key for [$STORAGE_ACCOUNT_NAME]..."
-STORAGE_ACCOUNT_KEY=$($AZ storage account keys list \
+STORAGE_ACCOUNT_KEY=$(az storage account keys list \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "[0].value" \
@@ -96,7 +86,7 @@ else
 fi
 
 # Get the storage account resource ID
-STORAGE_ACCOUNT_RESOURCE_ID=$($AZ storage account show \
+STORAGE_ACCOUNT_RESOURCE_ID=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "id" \
@@ -111,7 +101,7 @@ else
 fi
 
 # Get the storage account blob primary endpoint
-AZURE_STORAGE_ACCOUNT_URL=$($AZ storage account show \
+AZURE_STORAGE_ACCOUNT_URL=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "primaryEndpoints.blob" \
@@ -127,7 +117,7 @@ fi
 
 # Create blob container
 echo "Creating blob container [$CONTAINER_NAME] in the [$STORAGE_ACCOUNT_NAME] storage account..."
-$AZ storage container create \
+az storage container create \
 	--name $CONTAINER_NAME \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--account-key "$STORAGE_ACCOUNT_KEY" \
@@ -142,7 +132,7 @@ fi
 
 # Create App Service Plan
 echo "Creating App Service Plan [$APP_SERVICE_PLAN_NAME]..."
-$AZ appservice plan create \
+az appservice plan create \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--location "$LOCATION" \
@@ -159,7 +149,7 @@ fi
 
 # Create the web app
 echo "Creating web app [$WEB_APP_NAME]..."
-$AZ webapp create \
+az webapp create \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--plan "$APP_SERVICE_PLAN_NAME" \
 	--name "$WEB_APP_NAME" \
@@ -175,7 +165,7 @@ else
 fi
 
 # Retrieve the principalId of the system-assigned managed identity
-MANAGED_IDENTITY_PRINCIPAL_ID=$($AZ webapp identity show \
+MANAGED_IDENTITY_PRINCIPAL_ID=$(az webapp identity show \
 	--name "$WEB_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query principalId \
@@ -191,7 +181,7 @@ fi
 # Assign the Storage Blob Data Contributor role to the managed identity with the storage account as scope
 ROLE="Storage Blob Data Contributor"
 echo "Checking if the managed identity with principal ID [$MANAGED_IDENTITY_PRINCIPAL_ID] has the [$ROLE] role assignment on storage account [$STORAGE_ACCOUNT_NAME]..."
-current=$($AZ role assignment list \
+current=$(az role assignment list \
 	--assignee "$MANAGED_IDENTITY_PRINCIPAL_ID" \
 	--scope "$STORAGE_ACCOUNT_RESOURCE_ID" \
 	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
@@ -205,7 +195,7 @@ else
 	ATTEMPT=1
 	while [ $ATTEMPT -le $RETRY_COUNT ]; do
 		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
-		$AZ role assignment create \
+		az role assignment create \
 			--assignee "$MANAGED_IDENTITY_PRINCIPAL_ID" \
 			--role "$ROLE" \
 			--scope "$STORAGE_ACCOUNT_RESOURCE_ID" 1>/dev/null
@@ -231,7 +221,7 @@ fi
 
 # Set web app settings
 echo "Setting web app settings for [$WEB_APP_NAME]..."
-$AZ webapp config appsettings set \
+az webapp config appsettings set \
 	--name $WEB_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--settings \
@@ -262,7 +252,7 @@ zip -r "$ZIPFILE" app.py requirements.txt static templates
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-managed-identity/python/scripts/user-assigned.sh
+++ b/samples/web-app-managed-identity/python/scripts/user-assigned.sh
@@ -16,7 +16,6 @@ CONTAINER_NAME='activities'
 ZIPFILE="webapp_app.zip"
 SUBSCRIPTION_NAME=$(az account show --query name --output tsv)
 SUBSCRIPTION_ID=$(az account show --query id --output tsv)
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RETRY_COUNT=3
 SLEEP=5
@@ -24,25 +23,16 @@ SLEEP=5
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Create a resource group
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location "$LOCATION" \
 		--only-show-errors 1>/dev/null
@@ -59,14 +49,14 @@ fi
 
 # Create a storage account
 echo "Checking if storage account [$STORAGE_ACCOUNT_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ storage account show \
+az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No storage account [$STORAGE_ACCOUNT_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	echo "Creating storage account [$STORAGE_ACCOUNT_NAME] in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ storage account create \
+	az storage account create \
 		--name $STORAGE_ACCOUNT_NAME \
 		--location "$LOCATION" \
 		--resource-group $RESOURCE_GROUP_NAME \
@@ -84,7 +74,7 @@ fi
 
 # Get the storage account key
 echo "Getting storage account key for [$STORAGE_ACCOUNT_NAME]..."
-STORAGE_ACCOUNT_KEY=$($AZ storage account keys list \
+STORAGE_ACCOUNT_KEY=$(az storage account keys list \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "[0].value" \
@@ -98,7 +88,7 @@ else
 fi
 
 # Get the storage account resource ID
-STORAGE_ACCOUNT_RESOURCE_ID=$($AZ storage account show \
+STORAGE_ACCOUNT_RESOURCE_ID=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "id" \
@@ -113,7 +103,7 @@ else
 fi
 
 # Get the storage account blob primary endpoint
-AZURE_STORAGE_ACCOUNT_URL=$($AZ storage account show \
+AZURE_STORAGE_ACCOUNT_URL=$(az storage account show \
 	--name $STORAGE_ACCOUNT_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--query "primaryEndpoints.blob" \
@@ -129,7 +119,7 @@ fi
 
 # Create blob container
 echo "Creating blob container [$CONTAINER_NAME] in the [$STORAGE_ACCOUNT_NAME] storage account..."
-$AZ storage container create \
+az storage container create \
 	--name $CONTAINER_NAME \
 	--account-name $STORAGE_ACCOUNT_NAME \
 	--account-key "$STORAGE_ACCOUNT_KEY" \
@@ -144,7 +134,7 @@ fi
 
 # Check if the App Service Plan already exists
 echo "Checking if App Service Plan [$APP_SERVICE_PLAN_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ appservice plan show \
+az appservice plan show \
 	--name $APP_SERVICE_PLAN_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
@@ -152,7 +142,7 @@ if [[ $? != 0 ]]; then
 	echo "No App Service Plan [$APP_SERVICE_PLAN_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	# Create App Service Plan
 	echo "Creating App Service Plan [$APP_SERVICE_PLAN_NAME]..."
-	$AZ appservice plan create \
+	az appservice plan create \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--name "$APP_SERVICE_PLAN_NAME" \
 		--location "$LOCATION" \
@@ -173,7 +163,7 @@ fi
 # Check if the user-assigned managed identity already exists
 echo "Checking if [$MANAGED_IDENTITY_NAME] user-assigned managed identity actually exists in the [$RESOURCE_GROUP_NAME] resource group..."
 
-$AZ identity show \
+az identity show \
 	--name"$MANAGED_IDENTITY_NAME" \
 	--resource-group $"$RESOURCE_GROUP_NAME" &>/dev/null
 
@@ -182,7 +172,7 @@ if [[ $? != 0 ]]; then
 	echo "Creating [$MANAGED_IDENTITY_NAME] user-assigned managed identity in the [$RESOURCE_GROUP_NAME] resource group..."
 
 	# Create the user-assigned managed identity
-	$AZ identity create \
+	az identity create \
 		--name "$MANAGED_IDENTITY_NAME" \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--location "$LOCATION" \
@@ -200,7 +190,7 @@ fi
 
 # Retrieve the clientId of the user-assigned managed identity
 echo "Retrieving clientId for [$MANAGED_IDENTITY_NAME] managed identity..."
-CLIENT_ID=$($AZ identity show \
+CLIENT_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query clientId \
@@ -215,7 +205,7 @@ fi
 
 # Retrieve the principalId of the user-assigned managed identity
 echo "Retrieving principalId for [$MANAGED_IDENTITY_NAME] managed identity..."
-PRINCIPAL_ID=$($AZ identity show \
+PRINCIPAL_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query principalId \
@@ -230,7 +220,7 @@ fi
 
 # Retrieve the resource id of the user-assigned managed identity
 echo "Retrieving resource id for the [$MANAGED_IDENTITY_NAME] managed identity..."
-IDENTITY_ID=$($AZ identity show \
+IDENTITY_ID=$(az identity show \
 	--name "$MANAGED_IDENTITY_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query id \
@@ -245,7 +235,7 @@ fi
 
 # Check if the web app already exists
 echo "Checking if web app [$WEB_APP_NAME] exists in the resource group [$RESOURCE_GROUP_NAME]..."
-$AZ webapp show \
+az webapp show \
 	--name $WEB_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME &>/dev/null
 
@@ -253,7 +243,7 @@ if [[ $? != 0 ]]; then
 	echo "No web app [$WEB_APP_NAME] exists in the [$RESOURCE_GROUP_NAME] resource group."
 	# Create the web app
 	echo "Creating web app [$WEB_APP_NAME]..."
-	$AZ webapp create \
+	az webapp create \
 		--resource-group "$RESOURCE_GROUP_NAME" \
 		--plan "$APP_SERVICE_PLAN_NAME" \
 		--name "$WEB_APP_NAME" \
@@ -274,7 +264,7 @@ fi
 # Assign the Storage Blob Data Contributor role to the managed identity with the storage account as scope
 ROLE="Storage Blob Data Contributor"
 echo "Checking if the managed identity with principal ID [$PRINCIPAL_ID] has the [$ROLE] role assignment on storage account [$STORAGE_ACCOUNT_NAME]..."
-current=$($AZ role assignment list \
+current=$(az role assignment list \
 	--assignee "$PRINCIPAL_ID" \
 	--scope "$STORAGE_ACCOUNT_RESOURCE_ID" \
 	--query "[?roleDefinitionName=='$ROLE'].roleDefinitionName" \
@@ -288,7 +278,7 @@ else
 	ATTEMPT=1
 	while [ $ATTEMPT -le $RETRY_COUNT ]; do
 		echo "Attempt $ATTEMPT of $RETRY_COUNT to assign role..."
-		$AZ role assignment create \
+		az role assignment create \
 			--assignee "$PRINCIPAL_ID" \
 			--role "$ROLE" \
 			--scope "$STORAGE_ACCOUNT_RESOURCE_ID" 1>/dev/null
@@ -314,7 +304,7 @@ fi
 
 # Set web app settings
 echo "Setting web app settings for [$WEB_APP_NAME]..."
-$AZ webapp config appsettings set \
+az webapp config appsettings set \
 	--name $WEB_APP_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--settings \
@@ -346,7 +336,7 @@ zip -r "$ZIPFILE" app.py requirements.txt static templates
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-managed-identity/python/scripts/validate.sh
+++ b/samples/web-app-managed-identity/python/scripts/validate.sh
@@ -1,41 +1,30 @@
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/web-app-managed-identity/python/terraform/README.md
+++ b/samples/web-app-managed-identity/python/terraform/README.md
@@ -107,41 +107,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check storage account properties
-$AZ storage account show \
+az storage account show \
   --name localstoragetest \
   --resource-group local-rg \
   --output table
 
 # List storage containers
-$AZ storage container list \
+az storage container list \
   --account-name localstoragetest \
   --output table \
   --only-show-errors

--- a/samples/web-app-managed-identity/python/terraform/deploy.sh
+++ b/samples/web-app-managed-identity/python/terraform/deploy.sh
@@ -1,25 +1,15 @@
 #!/bin/bash
 
 # Variables
-PREFIX='webmi'
+PREFIX='local'
 SUFFIX='test'
 LOCATION='westeurope'
 MANAGED_IDENTITY_TYPE='SystemAssigned' # SystemAssigned or UserAssigned
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Run terraform init and apply
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
 
 echo "Initializing Terraform..."
 terraform init -upgrade
@@ -66,7 +56,7 @@ zip -r "$ZIPFILE" app.py activities.py database.py static templates requirements
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-sql-database/python/bicep/README.md
+++ b/samples/web-app-sql-database/python/bicep/README.md
@@ -79,41 +79,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Server
-$AZ sql server show \
+az sql server show \
 --name local-sqlserver-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Database
-$AZ sql db show \
+az sql db show \
 --name PlannerDB \
 --server local-sqlserver-test \
 --resource-group local-rg \

--- a/samples/web-app-sql-database/python/bicep/deploy.sh
+++ b/samples/web-app-sql-database/python/bicep/deploy.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Enable verbose debugging
-set -x
-
 # Variables
 PREFIX='local'
 SUFFIX='test'
@@ -19,37 +16,20 @@ DATABASE_USER_NAME='testuser'
 DATABASE_USER_PASSWORD='TestP@ssw0rd123'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 DEPLOY_APP=1
-
-echo "=================================================="
-echo "DEBUG: Starting bicep deployment for web-app-sql-database"
-echo "DEBUG: Resource Group: $RESOURCE_GROUP_NAME"
-echo "DEBUG: Environment: $ENVIRONMENT"
-echo "=================================================="
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]..."
-$AZ group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists in the subscription [$SUBSCRIPTION_NAME]"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME] in the subscription [$SUBSCRIPTION_NAME]..."
 
 	# Create the resource group
-	$AZ group create \
+	az group create \
 		--name $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
 		--only-show-errors 1>/dev/null
@@ -69,7 +49,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	if [[ $USE_WHAT_IF == 1 ]]; then
 		# Execute a deployment What-If operation at resource group scope.
 		echo "Previewing changes deployed by Bicep template [$TEMPLATE]..."
-		$AZ deployment group what-if \
+		az deployment group what-if \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -91,7 +71,7 @@ if [[ $VALIDATE_TEMPLATE == 1 ]]; then
 	else
 		# Validate the Bicep template
 		echo "Validating Bicep template [$TEMPLATE]..."
-		output=$($AZ deployment group validate \
+		output=$(az deployment group validate \
 			--resource-group $RESOURCE_GROUP_NAME \
 			--template-file $TEMPLATE \
 			--parameters $PARAMETERS \
@@ -116,7 +96,7 @@ fi
 
 # Deploy the Bicep template
 echo "Deploying Bicep template [$TEMPLATE]..."
-if DEPLOYMENT_OUTPUTS=$($AZ deployment group create \
+if DEPLOYMENT_OUTPUTS=$(az deployment group create \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors \
 	--template-file $TEMPLATE \
@@ -156,7 +136,7 @@ fi
 
 # Retrieve the fullyQualifiedDomainName of the SQL server
 echo "Retrieving the fullyQualifiedDomainName of the [$SQL_SERVER_NAME] SQL server..."
-SQL_SERVER_FQDN=$($AZ sql server show \
+SQL_SERVER_FQDN=$(az sql server show \
 	--name "$SQL_SERVER_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "fullyQualifiedDomainName" \
@@ -319,7 +299,7 @@ zip -r "$ZIPFILE" app.py activities.py database.py static templates requirements
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \

--- a/samples/web-app-sql-database/python/scripts/README.md
+++ b/samples/web-app-sql-database/python/scripts/README.md
@@ -79,41 +79,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Server
-$AZ sql server show \
+az sql server show \
 --name local-sqlserver-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Database
-$AZ sql db show \
+az sql db show \
 --name PlannerDB \
 --server local-sqlserver-test \
 --resource-group local-rg \

--- a/samples/web-app-sql-database/python/scripts/deploy.sh
+++ b/samples/web-app-sql-database/python/scripts/deploy.sh
@@ -21,26 +21,15 @@ ZIPFILE="planner_website.zip"
 RUNTIME="python"
 RUNTIME_VERSION="3.13"
 DEPLOY_APP=1
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 KEY_VAULT_NAME="${PREFIX}-kv-${SUFFIX}"
 SECRET_NAME="${PREFIX}-secret-${SUFFIX}"
 CERT_NAME="${PREFIX}-cert-${SUFFIX}"
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Create a resource group
 echo "Creating resource group [$RESOURCE_GROUP_NAME]..."
-$AZ group create \
+az group create \
 	--name $RESOURCE_GROUP_NAME \
 	--location $LOCATION \
 	--only-show-errors 1>/dev/null
@@ -54,7 +43,7 @@ fi
 
 # Create a sql server
 echo "Checking if [$SQL_SERVER_NAME] sql server exists in the [$RESOURCE_GROUP_NAME] resource group..."
-$AZ sql server show \
+az sql server show \
 	--name $SQL_SERVER_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--only-show-errors &>/dev/null
@@ -64,7 +53,7 @@ if [ $? -eq 0 ]; then
 else
 	echo "[$SQL_SERVER_NAME] sql server does not exist in the [$RESOURCE_GROUP_NAME] resource group. Proceeding to create it."
 	echo "Creating [$SQL_SERVER_NAME] sql server in the [$RESOURCE_GROUP_NAME] resource group..."
-	$AZ sql server create \
+	az sql server create \
 		--name $SQL_SERVER_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--location $LOCATION \
@@ -86,7 +75,7 @@ fi
 
 # Add firewall rule to allow all local network addresses (for testing/development)
 echo "Creating firewall rule to allow all IP addresses..."
-$AZ sql server firewall-rule create \
+az sql server firewall-rule create \
 	--name $FIREWALL_RULE_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--server $SQL_SERVER_NAME \
@@ -103,7 +92,7 @@ fi
 
 # Create database if it does not exist
 echo "Checking if [$SQL_DATABASE_NAME] database exists in the [$SQL_SERVER_NAME] sql server..."
-$AZ sql db show \
+az sql db show \
 	--name $SQL_DATABASE_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--server $SQL_SERVER_NAME \
@@ -113,7 +102,7 @@ if [ $? -eq 0 ]; then
 	echo "[$SQL_DATABASE_NAME] database already exists in the [$SQL_SERVER_NAME] sql server."
 else
 	echo "Creating [$SQL_DATABASE_NAME] database with Provisioned compute model in the [$SQL_SERVER_NAME] sql server..."
-	$AZ sql db create \
+	az sql db create \
 		--name $SQL_DATABASE_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
 		--server $SQL_SERVER_NAME \
@@ -133,7 +122,7 @@ fi
 
 # Retrieve the fullyQualifiedDomainName of the SQL server
 echo "Retrieving the fullyQualifiedDomainName of the [$SQL_SERVER_NAME] SQL server..."
-SQL_SERVER_FQDN=$($AZ sql server show \
+SQL_SERVER_FQDN=$(az sql server show \
 	--name "$SQL_SERVER_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "fullyQualifiedDomainName" \
@@ -294,7 +283,7 @@ fi
 
 # Create App Service Plan
 echo "Creating App Service Plan [$APP_SERVICE_PLAN_NAME]..."
-$AZ appservice plan create \
+az appservice plan create \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$APP_SERVICE_PLAN_NAME" \
 	--location "$LOCATION" \
@@ -311,7 +300,7 @@ fi
 
 # Create the web app
 echo "Creating web app [$WEB_APP_NAME]..."
-$AZ webapp create \
+az webapp create \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--plan "$APP_SERVICE_PLAN_NAME" \
 	--name "$WEB_APP_NAME" \
@@ -327,7 +316,7 @@ else
 fi
 
 # Get Web App principal ID
-PRINCIPAL_ID=$($AZ webapp identity show \
+PRINCIPAL_ID=$(az webapp identity show \
 	--name "$WEB_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "principalId" \
@@ -340,7 +329,7 @@ fi
 
 # Create Key Vault
 echo "Creating Key Vault [$KEY_VAULT_NAME]..."
-$AZ keyvault create \
+az keyvault create \
 	--name "$KEY_VAULT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--location "$LOCATION" \
@@ -356,7 +345,7 @@ fi
 
 # Assign access policy to Web App managed identity
 echo "Assigning Key Vault access policy to Web App..."
-$AZ keyvault set-policy \
+az keyvault set-policy \
 	--name "$KEY_VAULT_NAME" \
 	--object-id "$PRINCIPAL_ID" \
 	--secret-permissions get \
@@ -375,7 +364,7 @@ SQL_CONNECTION_STRING="Server=tcp:${SQL_SERVER_FQDN},1433;Database=${SQL_DATABAS
 
 # Create secret
 echo "Creating secret [$SECRET_NAME] in Key Vault..."
-$AZ keyvault secret set \
+az keyvault secret set \
 	--vault-name "$KEY_VAULT_NAME" \
 	--name "$SECRET_NAME" \
 	--value "$SQL_CONNECTION_STRING" \
@@ -390,7 +379,7 @@ fi
 
 # Create certificate in Key Vault
 echo "Creating certificate [$CERT_NAME] in Key Vault [$KEY_VAULT_NAME]..."
-$AZ keyvault certificate create \
+az keyvault certificate create \
     --vault-name "$KEY_VAULT_NAME" \
     --name "$CERT_NAME" \
     --policy '{
@@ -410,7 +399,7 @@ fi
 
 # Get Key Vault URI
 echo "Retrieving Key Vault URI..."
-KEYVAULT_URI=$($AZ keyvault show \
+KEYVAULT_URI=$(az keyvault show \
 	--name "$KEY_VAULT_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "properties.vaultUri" \
@@ -426,7 +415,7 @@ echo "Key Vault URI: [$KEYVAULT_URI]"
 # Pass Key Vault name and secret name as app settings.
 # The Python SDK will retrieve the actual connection string value from Key Vault.
 echo "Setting web app settings for [$WEB_APP_NAME]..."
-$AZ webapp config appsettings set \
+az webapp config appsettings set \
 	--name "$WEB_APP_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--settings \
@@ -465,7 +454,7 @@ zip -r "$ZIPFILE" app.py activities.py database.py certificates.py static templa
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \
@@ -480,7 +469,7 @@ else
 fi
 
 # Get web app URL
-WEB_APP_URL=$($AZ webapp show \
+WEB_APP_URL=$(az webapp show \
     --name "$WEB_APP_NAME" \
     --resource-group "$RESOURCE_GROUP_NAME" \
     --query "defaultHostName" \

--- a/samples/web-app-sql-database/python/scripts/get-web-app-url.sh
+++ b/samples/web-app-sql-database/python/scripts/get-web-app-url.sh
@@ -68,7 +68,7 @@ get_docker_container_port_mapping() {
 call_web_app() {
 	# Get the web app name
 	echo "Getting web app name..."
-	web_app_name=$(azlocal webapp list --query '[0].name' --output tsv)
+	web_app_name=$(az webapp list --query '[0].name' --output tsv)
 
 	if [ -n "$web_app_name" ]; then
 		echo "Web app [$web_app_name] successfully retrieved."
@@ -79,7 +79,7 @@ call_web_app() {
 
 	# Get the resource group name
 	echo "Getting resource group name for web app [$web_app_name]..."
-	resource_group_name=$(azlocal webapp list --query '[0].resourceGroup' --output tsv)
+	resource_group_name=$(az webapp list --query '[0].resourceGroup' --output tsv)
 
 	if [ -n "$resource_group_name" ]; then
 		echo "Resource group [$resource_group_name] successfully retrieved."
@@ -90,7 +90,7 @@ call_web_app() {
 
 	# Get the the default host name of the web app
 	echo "Getting the default host name of the web app [$web_app_name]..."
-	app_host_name=$(azlocal webapp show \
+	app_host_name=$(az webapp show \
 		--name "$web_app_name" \
 		--resource-group "$resource_group_name" \
 		--query 'defaultHostName' \

--- a/samples/web-app-sql-database/python/scripts/validate.sh
+++ b/samples/web-app-sql-database/python/scripts/validate.sh
@@ -1,54 +1,43 @@
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Server
-$AZ sql server show \
+az sql server show \
 --name local-sqlserver-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Database
-$AZ sql db show \
+az sql db show \
 --name PlannerDB \
 --server local-sqlserver-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure Key Vault
-$AZ keyvault show \
+az keyvault show \
 --name local-kv-test \
 --resource-group local-rg \
 --output table
 
 # Check Key Vault secret
-$AZ keyvault secret show \
+az keyvault secret show \
 --vault-name local-kv-test \
 --name local-secret-test \
 --query "{name:name, enabled:attributes.enabled, created:attributes.created}" \

--- a/samples/web-app-sql-database/python/terraform/README.md
+++ b/samples/web-app-sql-database/python/terraform/README.md
@@ -106,41 +106,30 @@ After deployment, you can use the `validate.sh` script to verify that all resour
 #!/bin/bash
 
 # Variables
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
-
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard az for AzureCloud environment."
-	AZ="az"
-fi
-
 # Check resource group
-$AZ group show \
+az group show \
 --name local-rg \
 --output table
 
 # List resources
-$AZ resource list \
+az resource list \
 --resource-group local-rg \
 --output table
 
 # Check Azure Web App
-$AZ webapp show \
+az webapp show \
 --name local-webapp-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Server
-$AZ sql server show \
+az sql server show \
 --name local-sqlserver-test \
 --resource-group local-rg \
 --output table
 
 # Check Azure SQL Database
-$AZ sql db show \
+az sql db show \
 --name PlannerDB \
 --server local-sqlserver-test \
 --resource-group local-rg \

--- a/samples/web-app-sql-database/python/terraform/deploy.sh
+++ b/samples/web-app-sql-database/python/terraform/deploy.sh
@@ -11,19 +11,9 @@ DATABASE_USER_PASSWORD='TestP@ssw0rd123'
 CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ZIPFILE="planner_website.zip"
 DEPLOY_APP=1
-ENVIRONMENT=$(az account show --query environmentName --output tsv)
 
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
-
-# Run terraform init and apply
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
 
 echo "Initializing Terraform..."
 terraform init -upgrade
@@ -61,7 +51,7 @@ fi
 
 # Retrieve the fullyQualifiedDomainName of the SQL server
 echo "Retrieving the fullyQualifiedDomainName of the [$SQL_SERVER_NAME] SQL server..."
-SQL_SERVER_FQDN=$($AZ sql server show \
+SQL_SERVER_FQDN=$(az sql server show \
 	--name "$SQL_SERVER_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--query "fullyQualifiedDomainName" \
@@ -231,7 +221,7 @@ zip -r "$ZIPFILE" app.py activities.py database.py static templates requirements
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-$AZ webapp deploy \
+az webapp deploy \
 	--resource-group "$RESOURCE_GROUP_NAME" \
 	--name "$WEB_APP_NAME" \
 	--src-path "$ZIPFILE" \


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Due to the recent introduction of the certificate for the Azure emulator and the refactoring of the fully qualified names of emulated services, the use of the `azlocal` CLI is no longer necessary. Hence, this pull request introduces the necessary changes to replace the `azlocal` with `az` in the following samples:

| Sample Name | Description |
|-------------|-------------|
| [Function App and Storage](https://github.com/localstack/localstack-azure-samples/samples/function-app-storage-http/dotnet/README.md) | Azure Functions App using Blob, Queue, and Table Storage |
| [Function App and Managed Identities](https://github.com/localstack/localstack-azure-samples/samples/function-app-managed-identity/python/README.md) | Azure Function App using Managed Identities |
| [Function App and Service Bus](https://github.com/localstack/localstack-azure-samples/samples/function-app-service-bus/dotnet/README.md) | Azure Function App using Service Bus |
| [Web App and CosmosDB for MongoDB API ](https://github.com/localstack/localstack-azure-samples/samples/web-app-cosmosdb-mongodb-api/python/README.md) | Azure Web App using CosmosDB for MongoDB API |
| [Web App and Managed Identities](https://github.com/localstack/localstack-azure-samples/samples/web-app-managed-identity/python/README.md) | Azure Web App using Managed Identities |
| [Web App and SQL Database ](https://github.com/localstack/localstack-azure-samples/samples/web-app-sql-database/python/README.md) | Azure Web App using SQL Database |
| [Azure Service Bus with Spring Boot](https://github.com/localstack/localstack-azure-samples/samples/servicebus/README.md) | Azure Service Bus used by a Spring Boot application |

## Changes
This pull requests removes this test from `.sh` Bash scripts:

```bash
...
ENVIRONMENT=$(az account show --query environmentName --output tsv)
...
# Run terraform init and apply
if [[ $ENVIRONMENT == "LocalStack" ]]; then
	echo "Using azlocal for LocalStack emulator environment."
	AZ="azlocal"
else
	echo "Using standard terraform and az for AzureCloud environment."
	AZ="az"
fi
```

In addition, it replaces `$AZ` with `az`.

## Next Steps
@DrisDary / @alexlave100 when this pull request is complete, please run `git pull origin main` and replace `azlocal` with `az` in the following samples:

| Sample Name | Description |
|-------------|-------------|
| [Function App and Front Door](https://github.com/localstack/localstack-azure-samples/samples/function-app-front-door/python/README.md) | Azure Functions App exposed via Front Door |
| [ACI and Blob Storage](https://github.com/localstack/localstack-azure-samples/samples/aci-blob-storage/python/README.md) | Azure Container Instances with ACR, Key Vault, and Blob Storage |
| [Web App and CosmosDB for NoSQL API ](https://github.com/localstack/localstack-azure-samples/samples/web-app-cosmosdb-nosql-api/python/README.md) | Azure Web App using CosmosDB for NoSQL API |

