### PR TITLE
azlocal to az

### DIFF
--- a/run-samples.sh
+++ b/run-samples.sh
@@ -121,17 +121,17 @@ if [ -n "${AZURE_CONFIG_DIR:-}" ]; then
   mkdir -p "$AZURE_CONFIG_DIR"
 fi
 
-if command -v az >/dev/null 2>&1; then
-  echo "[DEBUG] az command found, attempting login..."
-  az login || true
-  echo "[DEBUG] Starting az interception..."
-  az start-interception
+if command -v azlocal >/dev/null 2>&1; then
+  echo "[DEBUG] azlocal command found, attempting login..."
+  azlocal login || true
+  echo "[DEBUG] Starting azlocal interception..."
+  azlocal start-interception
   echo "[DEBUG] Setting default subscription..."
-  az account set --subscription "00000000-0000-0000-0000-000000000000" || true
-  echo "[DEBUG] Checking az account status..."
-  az account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] az account show failed"
+  azlocal account set --subscription "00000000-0000-0000-0000-000000000000" || true
+  echo "[DEBUG] Checking azlocal account status..."
+  azlocal account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] azlocal account show failed"
 else
-  echo "[DEBUG] az not found, using standard az login with service principal..."
+  echo "[DEBUG] azlocal not found, using standard az login with service principal..."
   az login --service-principal -u any-app -p any-pass --tenant any-tenant || true
   echo "[DEBUG] Checking az account status..."
   az account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] az account show failed"
@@ -188,13 +188,13 @@ for (( i=START; i<START+COUNT; i++ )); do
 
   # Clean up Azure resources to prevent state pollution between tests
   echo "Cleaning up Azure resources in LocalStack..."
-  if command -v az >/dev/null 2>&1; then
-    RG_LIST=$(az group list --query "[].name" -o tsv 2>/dev/null || echo "")
+  if command -v azlocal >/dev/null 2>&1; then
+    RG_LIST=$(azlocal group list --query "[].name" -o tsv 2>/dev/null || echo "")
     if [[ -n "$RG_LIST" ]]; then
       echo "$RG_LIST" | while read -r rg; do
         if [[ -n "$rg" ]]; then
           echo "  - Deleting resource group: $rg"
-          az group delete --name "$rg" --yes --no-wait 2>/dev/null || true
+          azlocal group delete --name "$rg" --yes --no-wait 2>/dev/null || true
         fi
       done
       sleep 2

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -30,7 +30,7 @@ fi
 # 1. Define Samples (placed before tool checks so --list works without dependencies)
 SAMPLES=(
   "samples/servicebus/java|bash scripts/deploy.sh"
-  "samples/function-app-front-door/python|bash scripts/deploy_all.sh --name-prefix testafd --use-localstack|"
+  "samples/function-app-front-door/python|bash scripts/deploy_all.sh --name-prefix testafd|"
   "samples/function-app-managed-identity/python|bash scripts/user-managed-identity.sh|bash scripts/validate.sh && bash scripts/test.sh"
   "samples/function-app-service-bus/dotnet|bash scripts/deploy.sh|bash scripts/validate.sh && bash scripts/call-http-trigger.sh"
   "samples/function-app-storage-http/dotnet|bash scripts/deploy.sh|bash scripts/validate.sh && bash scripts/call-http-triggers.sh"

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -121,17 +121,17 @@ if [ -n "${AZURE_CONFIG_DIR:-}" ]; then
   mkdir -p "$AZURE_CONFIG_DIR"
 fi
 
-if command -v azlocal >/dev/null 2>&1; then
-  echo "[DEBUG] azlocal command found, attempting login..."
-  azlocal login || true
-  echo "[DEBUG] Starting azlocal interception..."
-  azlocal start-interception
+if command -v az >/dev/null 2>&1; then
+  echo "[DEBUG] az command found, attempting login..."
+  az login || true
+  echo "[DEBUG] Starting az interception..."
+  az start-interception
   echo "[DEBUG] Setting default subscription..."
-  azlocal account set --subscription "00000000-0000-0000-0000-000000000000" || true
-  echo "[DEBUG] Checking azlocal account status..."
-  azlocal account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] azlocal account show failed"
+  az account set --subscription "00000000-0000-0000-0000-000000000000" || true
+  echo "[DEBUG] Checking az account status..."
+  az account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] az account show failed"
 else
-  echo "[DEBUG] azlocal not found, using standard az login with service principal..."
+  echo "[DEBUG] az not found, using standard az login with service principal..."
   az login --service-principal -u any-app -p any-pass --tenant any-tenant || true
   echo "[DEBUG] Checking az account status..."
   az account show --query "{Environment:environmentName, Subscription:id}" --output json 2>&1 || echo "[DEBUG] az account show failed"
@@ -188,13 +188,13 @@ for (( i=START; i<START+COUNT; i++ )); do
 
   # Clean up Azure resources to prevent state pollution between tests
   echo "Cleaning up Azure resources in LocalStack..."
-  if command -v azlocal >/dev/null 2>&1; then
-    RG_LIST=$(azlocal group list --query "[].name" -o tsv 2>/dev/null || echo "")
+  if command -v az >/dev/null 2>&1; then
+    RG_LIST=$(az group list --query "[].name" -o tsv 2>/dev/null || echo "")
     if [[ -n "$RG_LIST" ]]; then
       echo "$RG_LIST" | while read -r rg; do
         if [[ -n "$rg" ]]; then
           echo "  - Deleting resource group: $rg"
-          azlocal group delete --name "$rg" --yes --no-wait 2>/dev/null || true
+          az group delete --name "$rg" --yes --no-wait 2>/dev/null || true
         fi
       done
       sleep 2

--- a/samples/aci-blob-storage/python/scripts/cleanup.sh
+++ b/samples/aci-blob-storage/python/scripts/cleanup.sh
@@ -16,13 +16,6 @@ KEY_VAULT_NAME="${PREFIX}acikv"
 ACR_NAME="${PREFIX}aciacr"
 STORAGE_ACCOUNT_NAME="${PREFIX}acistorage"
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	AZ="azlocal"
-else
-	AZ="az"
-fi
-
 echo "============================================================"
 echo "Cleaning up ACI Vacation Planner Resources"
 echo "============================================================"

--- a/samples/aci-blob-storage/python/scripts/validate.sh
+++ b/samples/aci-blob-storage/python/scripts/validate.sh
@@ -19,13 +19,6 @@ ACI_GROUP_NAME="${PREFIX}-aci-planner"
 PASS_COUNT=0
 FAIL_COUNT=0
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	AZ="azlocal"
-else
-	AZ="az"
-fi
-
 check() {
 	local description="$1"
 	local command="$2"

--- a/samples/aci-blob-storage/python/terraform/deploy.sh
+++ b/samples/aci-blob-storage/python/terraform/deploy.sh
@@ -11,15 +11,6 @@ CURRENT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Change the current directory to the script's directory
 cd "$CURRENT_DIR" || exit
 
-# Choose the appropriate CLI based on the environment
-if [[ $ENVIRONMENT == "LocalStack" ]]; then
-	echo "Using azlocal for LocalStack emulator environment."
-	AZ="azlocal"
-else
-	echo "Using standard terraform and az for AzureCloud environment."
-	AZ="az"
-fi
-
 # =============================================================================
 # Build and push the Docker image before Terraform deployment
 # (Terraform references the pre-created ACR as a data source)

--- a/samples/function-app-front-door/python/scripts/cleanup_all.sh
+++ b/samples/function-app-front-door/python/scripts/cleanup_all.sh
@@ -27,6 +27,7 @@ Usage: $(basename "$0") [--env-file PATH] [--resource-group NAME] [--use-localst
 Options:
   --env-file PATH         Env file produced by deploy_all.sh (e.g., scripts/.last_deploy_all.env)
   -g, --resource-group    Resource group name to delete
+      --use-localstack    Use azlocal interception to target LocalStack emulator
   -h, --help              Show this help
 EOF
 }
@@ -58,8 +59,8 @@ fi
 INTERCEPTION_STARTED="false"
 AZURE_CONFIG_DIR_CREATED="false"
 finish() {
-  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v az >/dev/null 2>&1; then
-    set +e; az stop-interception >/dev/null 2>&1 || true; set -e
+  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
+    set +e; azlocal stop-interception >/dev/null 2>&1 || true; set -e
   fi
   if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
     rm -rf "$AZURE_CONFIG_DIR"
@@ -68,17 +69,17 @@ finish() {
 trap finish EXIT
 
 if [[ "$USE_LOCALSTACK" == "true" ]]; then
-  if command -v mktemp >/dev/null 2>&1; then AZ_TEMP_CONFIG_DIR="$(mktemp -d)"; else AZ_TEMP_CONFIG_DIR="$(pwd)/.az_config_$$"; mkdir -p "$AZ_TEMP_CONFIG_DIR"; fi
+  if command -v mktemp >/dev/null 2>&1; then AZ_TEMP_CONFIG_DIR="$(mktemp -d)"; else AZ_TEMP_CONFIG_DIR="$(pwd)/.azlocal_config_$$"; mkdir -p "$AZ_TEMP_CONFIG_DIR"; fi
   export AZURE_CONFIG_DIR="$AZ_TEMP_CONFIG_DIR"; AZURE_CONFIG_DIR_CREATED="true"
   echo "Using isolated AZURE_CONFIG_DIR at: $AZURE_CONFIG_DIR"
-  if ! command -v az >/dev/null 2>&1; then
-    echo "Error: --use-localstack specified but 'az' was not found in PATH." >&2
+  if ! command -v azlocal >/dev/null 2>&1; then
+    echo "Error: --use-localstack specified but 'azlocal' was not found in PATH." >&2
     exit 1
   fi
-  if az start-interception; then
+  if azlocal start-interception; then
     INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
   else
-    echo "Error: az failed to start interception. Ensure LocalStack is running and az is configured correctly." >&2
+    echo "Error: azlocal failed to start interception. Ensure LocalStack is running and azlocal is configured correctly." >&2
     exit 1
   fi
 fi

--- a/samples/function-app-front-door/python/scripts/cleanup_all.sh
+++ b/samples/function-app-front-door/python/scripts/cleanup_all.sh
@@ -27,7 +27,6 @@ Usage: $(basename "$0") [--env-file PATH] [--resource-group NAME] [--use-localst
 Options:
   --env-file PATH         Env file produced by deploy_all.sh (e.g., scripts/.last_deploy_all.env)
   -g, --resource-group    Resource group name to delete
-      --use-localstack    Use azlocal interception to target LocalStack emulator
   -h, --help              Show this help
 EOF
 }
@@ -59,8 +58,8 @@ fi
 INTERCEPTION_STARTED="false"
 AZURE_CONFIG_DIR_CREATED="false"
 finish() {
-  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
-    set +e; azlocal stop-interception >/dev/null 2>&1 || true; set -e
+  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v az >/dev/null 2>&1; then
+    set +e; az stop-interception >/dev/null 2>&1 || true; set -e
   fi
   if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
     rm -rf "$AZURE_CONFIG_DIR"
@@ -69,17 +68,17 @@ finish() {
 trap finish EXIT
 
 if [[ "$USE_LOCALSTACK" == "true" ]]; then
-  if command -v mktemp >/dev/null 2>&1; then AZ_TEMP_CONFIG_DIR="$(mktemp -d)"; else AZ_TEMP_CONFIG_DIR="$(pwd)/.azlocal_config_$$"; mkdir -p "$AZ_TEMP_CONFIG_DIR"; fi
+  if command -v mktemp >/dev/null 2>&1; then AZ_TEMP_CONFIG_DIR="$(mktemp -d)"; else AZ_TEMP_CONFIG_DIR="$(pwd)/.az_config_$$"; mkdir -p "$AZ_TEMP_CONFIG_DIR"; fi
   export AZURE_CONFIG_DIR="$AZ_TEMP_CONFIG_DIR"; AZURE_CONFIG_DIR_CREATED="true"
   echo "Using isolated AZURE_CONFIG_DIR at: $AZURE_CONFIG_DIR"
-  if ! command -v azlocal >/dev/null 2>&1; then
-    echo "Error: --use-localstack specified but 'azlocal' was not found in PATH." >&2
+  if ! command -v az >/dev/null 2>&1; then
+    echo "Error: --use-localstack specified but 'az' was not found in PATH." >&2
     exit 1
   fi
-  if azlocal start-interception; then
+  if az start-interception; then
     INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
   else
-    echo "Error: azlocal failed to start interception. Ensure LocalStack is running and azlocal is configured correctly." >&2
+    echo "Error: az failed to start interception. Ensure LocalStack is running and az is configured correctly." >&2
     exit 1
   fi
 fi

--- a/samples/function-app-front-door/python/scripts/cleanup_all.sh
+++ b/samples/function-app-front-door/python/scripts/cleanup_all.sh
@@ -8,26 +8,23 @@ set -euo pipefail
 #
 # Usage examples:
 #   # Using the env file written by deploy_all.sh
-#   bash ./scripts/cleanup_all.sh --env-file ./scripts/.last_deploy_all.env --use-localstack
+#   bash ./scripts/cleanup_all.sh --env-file ./scripts/.last_deploy_all.env
 #
-#   # Passing the RG directly (works for Azure or LocalStack)
+#   # Passing the RG directly
 #   bash ./scripts/cleanup_all.sh --resource-group rg-funcafdall-12345
 #
 # Requirements: az CLI
-# Optional: azlocal (LocalStack Azure CLI helper) when cleaning emulator resources
 
 RESOURCE_GROUP=""
 ENV_FILE=""
-USE_LOCALSTACK="false"
 
 print_usage() {
   cat <<EOF
-Usage: $(basename "$0") [--env-file PATH] [--resource-group NAME] [--use-localstack]
+Usage: $(basename "$0") [--env-file PATH] [--resource-group NAME]
 
 Options:
   --env-file PATH         Env file produced by deploy_all.sh (e.g., scripts/.last_deploy_all.env)
   -g, --resource-group    Resource group name to delete
-      --use-localstack    Use azlocal interception to target LocalStack emulator
   -h, --help              Show this help
 EOF
 }
@@ -37,7 +34,6 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --env-file) ENV_FILE=${2:-}; shift 2;;
     -g|--resource-group) RESOURCE_GROUP=${2:-}; shift 2;;
-    --use-localstack) USE_LOCALSTACK="true"; shift;;
     -h|--help) print_usage; exit 0;;
     *) echo "Unknown option: $1" >&2; print_usage; exit 1;;
   esac
@@ -54,34 +50,6 @@ fi
 if [[ -z "$RESOURCE_GROUP" ]]; then
   echo "Resource group not specified. Provide -g/--resource-group or --env-file pointing to deploy env." >&2
   exit 1
-fi
-
-INTERCEPTION_STARTED="false"
-AZURE_CONFIG_DIR_CREATED="false"
-finish() {
-  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
-    set +e; azlocal stop-interception >/dev/null 2>&1 || true; set -e
-  fi
-  if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
-    rm -rf "$AZURE_CONFIG_DIR"
-  fi
-}
-trap finish EXIT
-
-if [[ "$USE_LOCALSTACK" == "true" ]]; then
-  if command -v mktemp >/dev/null 2>&1; then AZ_TEMP_CONFIG_DIR="$(mktemp -d)"; else AZ_TEMP_CONFIG_DIR="$(pwd)/.azlocal_config_$$"; mkdir -p "$AZ_TEMP_CONFIG_DIR"; fi
-  export AZURE_CONFIG_DIR="$AZ_TEMP_CONFIG_DIR"; AZURE_CONFIG_DIR_CREATED="true"
-  echo "Using isolated AZURE_CONFIG_DIR at: $AZURE_CONFIG_DIR"
-  if ! command -v azlocal >/dev/null 2>&1; then
-    echo "Error: --use-localstack specified but 'azlocal' was not found in PATH." >&2
-    exit 1
-  fi
-  if azlocal start-interception; then
-    INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
-  else
-    echo "Error: azlocal failed to start interception. Ensure LocalStack is running and azlocal is configured correctly." >&2
-    exit 1
-  fi
 fi
 
 az group delete -n "$RESOURCE_GROUP" --yes --no-wait

--- a/samples/function-app-front-door/python/scripts/deploy_all.sh
+++ b/samples/function-app-front-door/python/scripts/deploy_all.sh
@@ -154,8 +154,8 @@ finish() {
   [[ -f "$ZIP_MAIN" ]] && rm -f "$ZIP_MAIN"
   [[ -f "$ZIP_A" ]] && rm -f "$ZIP_A"
   [[ -f "$ZIP_B" ]] && rm -f "$ZIP_B"
-  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v az >/dev/null 2>&1; then
-    az stop-interception >/dev/null 2>&1 || true
+  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
+    azlocal stop-interception >/dev/null 2>&1 || true
   fi
   if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
     rm -rf "$AZURE_CONFIG_DIR"
@@ -176,7 +176,7 @@ if [[ "$USE_LOCALSTACK" == "true" ]]; then
     echo "Error: --use-localstack specified but 'azlocal' not found in PATH." >&2
     exit 1
   fi
-  if az start-interception; then
+  if azlocal start-interception; then
     INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
   else
     echo "Error: azlocal failed to start interception. Ensure LocalStack is running." >&2

--- a/samples/function-app-front-door/python/scripts/deploy_all.sh
+++ b/samples/function-app-front-door/python/scripts/deploy_all.sh
@@ -354,6 +354,18 @@ hostBasic=""; hostMulti=""; hostSpec=""; hostRules=""; hostState=""
 [[ "$DO_RULES" == "true" ]] && hostRules=$(resolve_ep_host "$epRules")
 [[ "$DO_STATE" == "true" ]] && hostState=$(resolve_ep_host "$epState")
 
+# Detect LocalStack environment for local URLs
+IS_LOCALSTACK="false"
+ENVIRONMENT=$(az account show --query environmentName --output tsv 2>/dev/null || true)
+if [[ "$ENVIRONMENT" == "LocalStack" ]]; then
+  IS_LOCALSTACK="true"
+  epBasicLocal="${epBasic}.afd.localhost.localstack.cloud:4566"
+  epMultiLocal="${epMulti}.afd.localhost.localstack.cloud:4566"
+  epSpecLocal="${epSpec}.afd.localhost.localstack.cloud:4566"
+  epRulesLocal="${epRules}.afd.localhost.localstack.cloud:4566"
+  epStateLocal="${epState}.afd.localhost.localstack.cloud:4566"
+fi
+
 # -------------------------------
 # Persist environment for cleanup
 # -------------------------------
@@ -379,20 +391,28 @@ echo "Deployment complete."
 echo "Resource Group: $RESOURCE_GROUP"
 if [[ "$DO_BASIC" == "true" ]]; then
   echo "[Basic] AFD Endpoint:         https://$hostBasic/john"
+  [[ "$IS_LOCALSTACK" == "true" ]] && echo "       Local Endpoint:        http://$epBasicLocal/john"
 fi
 if [[ "$DO_MULTI" == "true" ]]; then
   echo "[Multi] AFD Endpoint:         https://$hostMulti/john"
+  [[ "$IS_LOCALSTACK" == "true" ]] && echo "       Local Endpoint:        http://$epMultiLocal/john"
 fi
 if [[ "$DO_SPEC" == "true" ]]; then
   echo "[Spec]  AFD Endpoint:         https://$hostSpec/john  (specific route)"
   echo "       Also try:              https://$hostSpec/jane  (catch-all)"
+  if [[ "$IS_LOCALSTACK" == "true" ]]; then
+    echo "       Local Endpoint:        http://$epSpecLocal/john  (specific route)"
+    echo "       Also try:              http://$epSpecLocal/jane  (catch-all)"
+  fi
 fi
 if [[ "$DO_RULES" == "true" ]]; then
   echo "[Rules] AFD Endpoint:         https://$hostRules/john"
   echo "       Expect response header: X-CDN: MSFT (once propagation completes)."
+  [[ "$IS_LOCALSTACK" == "true" ]] && echo "       Local Endpoint:        http://$epRulesLocal/john"
 fi
 if [[ "$DO_STATE" == "true" ]]; then
   echo "[State] AFD Endpoint:         https://$hostState/john"
+  [[ "$IS_LOCALSTACK" == "true" ]] && echo "       Local Endpoint:        http://$epStateLocal/john"
   echo "       To test enabled-state toggle:"
   echo "         az afd endpoint update -g $RESOURCE_GROUP --profile-name $profileName --endpoint-name $epState --enabled-state Disabled"
   echo "         # Then re-enable:"

--- a/samples/function-app-front-door/python/scripts/deploy_all.sh
+++ b/samples/function-app-front-door/python/scripts/deploy_all.sh
@@ -154,8 +154,8 @@ finish() {
   [[ -f "$ZIP_MAIN" ]] && rm -f "$ZIP_MAIN"
   [[ -f "$ZIP_A" ]] && rm -f "$ZIP_A"
   [[ -f "$ZIP_B" ]] && rm -f "$ZIP_B"
-  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
-    azlocal stop-interception >/dev/null 2>&1 || true
+  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v az >/dev/null 2>&1; then
+    az stop-interception >/dev/null 2>&1 || true
   fi
   if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
     rm -rf "$AZURE_CONFIG_DIR"
@@ -176,7 +176,7 @@ if [[ "$USE_LOCALSTACK" == "true" ]]; then
     echo "Error: --use-localstack specified but 'azlocal' not found in PATH." >&2
     exit 1
   fi
-  if azlocal start-interception; then
+  if az start-interception; then
     INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
   else
     echo "Error: azlocal failed to start interception. Ensure LocalStack is running." >&2

--- a/samples/function-app-front-door/python/scripts/deploy_all.sh
+++ b/samples/function-app-front-door/python/scripts/deploy_all.sh
@@ -10,20 +10,16 @@ set -euo pipefail
 #   4) Rules Engine demo via Rule Set + Rule (ep-rules)
 #   5) Endpoint enabled/disabled state toggle (ep-state)
 #
-# It supports deploying to real Azure or to LocalStack’s Azure emulator via azlocal interception.
 # By default, all scenarios are deployed. You can selectively skip scenarios via flags.
 #
 # Requirements
 #   - az CLI
 #   - bash, zip
-#   - Optional for LocalStack mode: azlocal (CLI interceptor), funclocal + Azure Functions Core Tools ('func')
+#   - Optional: Azure Functions Core Tools (‘func’)
 #
 # Examples
 #   # Real Azure (eastus by default)
 #   bash ./scripts/deploy_all.sh --name-prefix demo
-#
-#   # LocalStack emulator
-#   bash ./scripts/deploy_all.sh --name-prefix demo --use-localstack
 #
 
 # -------------------------------
@@ -32,7 +28,6 @@ set -euo pipefail
 NAME_PREFIX="funcafdall"
 LOCATION="eastus"
 RESOURCE_GROUP=""
-USE_LOCALSTACK="false"
 PYTHON_VERSION="3.11"
 
 # Scenario toggles
@@ -51,7 +46,6 @@ Options:
   -l, --location STR          Azure region (default: eastus)
   -g, --resource-group STR    Resource group name (auto-generated if omitted)
       --python-version STR    Python runtime for Function App(s) (default: 3.11)
-      --use-localstack        Use azlocal/funclocal for LocalStack emulator
 
   # Scenario toggles (all enabled by default)
       --no-basic              Skip basic single-origin scenario
@@ -70,7 +64,6 @@ while [[ $# -gt 0 ]]; do
     -l|--location) LOCATION=${2:-}; shift 2;;
     -g|--resource-group) RESOURCE_GROUP=${2:-}; shift 2;;
     --python-version) PYTHON_VERSION=${2:-}; shift 2;;
-    --use-localstack) USE_LOCALSTACK="true"; shift;;
     --no-basic) DO_BASIC="false"; shift;;
     --no-multi) DO_MULTI="false"; shift;;
     --no-spec) DO_SPEC="false"; shift;;
@@ -145,44 +138,16 @@ ruleSetName="rs${prefix}${suffix}"
 ruleName="ruleAddHeader"
 
 # -------------------------------
-# LocalStack interception lifecycle (optional)
+# Cleanup on exit
 # -------------------------------
-INTERCEPTION_STARTED="false"
-AZURE_CONFIG_DIR_CREATED="false"
 finish() {
   set +e
   [[ -f "$ZIP_MAIN" ]] && rm -f "$ZIP_MAIN"
   [[ -f "$ZIP_A" ]] && rm -f "$ZIP_A"
   [[ -f "$ZIP_B" ]] && rm -f "$ZIP_B"
-  if [[ "$INTERCEPTION_STARTED" == "true" ]] && command -v azlocal >/dev/null 2>&1; then
-    azlocal stop-interception >/dev/null 2>&1 || true
-  fi
-  if [[ "$AZURE_CONFIG_DIR_CREATED" == "true" && -n "${AZURE_CONFIG_DIR:-}" && -d "$AZURE_CONFIG_DIR" ]]; then
-    rm -rf "$AZURE_CONFIG_DIR"
-  fi
   set -e
 }
 trap finish EXIT
-
-if [[ "$USE_LOCALSTACK" == "true" ]]; then
-  if command -v mktemp >/dev/null 2>&1; then
-    AZ_TEMP_CONFIG_DIR="$(mktemp -d)"
-  else
-    AZ_TEMP_CONFIG_DIR="$ROOT_DIR/.azlocal_config_$$"; mkdir -p "$AZ_TEMP_CONFIG_DIR"
-  fi
-  export AZURE_CONFIG_DIR="$AZ_TEMP_CONFIG_DIR"; AZURE_CONFIG_DIR_CREATED="true"
-  echo "Using isolated AZURE_CONFIG_DIR: $AZURE_CONFIG_DIR"
-  if ! command -v azlocal >/dev/null 2>&1; then
-    echo "Error: --use-localstack specified but 'azlocal' not found in PATH." >&2
-    exit 1
-  fi
-  if azlocal start-interception; then
-    INTERCEPTION_STARTED="true"; echo "LocalStack interception started."
-  else
-    echo "Error: azlocal failed to start interception. Ensure LocalStack is running." >&2
-    exit 1
-  fi
-fi
 
 echo "Resource Group: $RESOURCE_GROUP"
 
@@ -202,38 +167,14 @@ create_function_app() {
     --runtime python --runtime-version "$PYTHON_VERSION" \
     --functions-version 4 --os-type Linux \
     --storage-account "$storageName" --disable-app-insights -o none
-  if [[ "$USE_LOCALSTACK" != "true" ]]; then
-    az functionapp config appsettings set -g "$RESOURCE_GROUP" -n "$funcName" \
-      --settings WEBSITE_RUN_FROM_PACKAGE=1 FUNCTIONS_WORKER_RUNTIME=python SCM_DO_BUILD_DURING_DEPLOYMENT=false -o none
-  else
-    az functionapp config appsettings set -g "$RESOURCE_GROUP" -n "$funcName" \
-      --settings FUNCTIONS_WORKER_RUNTIME=python WEBSITE_RUN_FROM_PACKAGE=0 -o none
-    local STORAGE_KEY
-    STORAGE_KEY=$(az storage account keys list -g "$RESOURCE_GROUP" -n "$storageName" --query "[0].value" -o tsv)
-    if [[ -z "$STORAGE_KEY" ]]; then echo "Failed to get storage key for $storageName" >&2; exit 1; fi
-    local STORAGE_CONNECTION_STRING
-    STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;AccountName=$storageName;AccountKey=$STORAGE_KEY;BlobEndpoint=http://$storageName.blob.localhost.localstack.cloud:4566;QueueEndpoint=http://$storageName.queue.localhost.localstack.cloud:4566;TableEndpoint=http://$storageName.table.localhost.localstack.cloud:4566;FileEndpoint=http://$storageName.file.localhost.localstack.cloud:4566"
-    az functionapp config appsettings set -g "$RESOURCE_GROUP" -n "$funcName" \
-      --settings AzureWebJobsStorage="$STORAGE_CONNECTION_STRING" WEBSITE_CONTENTAZUREFILECONNECTIONSTRING="$STORAGE_CONNECTION_STRING" SCM_RUN_FROM_PACKAGE= -o none
-  fi
+  az functionapp config appsettings set -g "$RESOURCE_GROUP" -n "$funcName" \
+    --settings WEBSITE_RUN_FROM_PACKAGE=1 FUNCTIONS_WORKER_RUNTIME=python SCM_DO_BUILD_DURING_DEPLOYMENT=false -o none
 }
 
 publish_function_code() {
   local funcName="$1"; local zipPath="$2"
-  if [[ "$USE_LOCALSTACK" == "true" ]]; then
-    if ! command -v funclocal >/dev/null 2>&1; then
-      echo "Error: funclocal is required in --use-localstack mode." >&2; exit 1
-    fi
-    if ! command -v func >/dev/null 2>&1; then
-      echo "Error: Azure Functions Core Tools ('func') not found in PATH." >&2; exit 1
-    fi
-    pushd "$FUNCTION_SRC" >/dev/null
-    funclocal azure functionapp publish "$funcName" --python --build local #--verbose --debug
-    popd >/dev/null
-  else
-    rm -f "$zipPath"; ( cd "$FUNCTION_SRC" && zip -rq "$zipPath" . )
-    az functionapp deployment source config-zip -g "$RESOURCE_GROUP" -n "$funcName" --src "$zipPath"
-  fi
+  rm -f "$zipPath"; ( cd "$FUNCTION_SRC" && zip -rq "$zipPath" . )
+  az functionapp deployment source config-zip -g "$RESOURCE_GROUP" -n "$funcName" --src "$zipPath"
 }
 
 if [[ "$DO_BASIC" == "true" || "$DO_SPEC" == "true" || "$DO_RULES" == "true" || "$DO_STATE" == "true" ]]; then
@@ -413,18 +354,6 @@ hostBasic=""; hostMulti=""; hostSpec=""; hostRules=""; hostState=""
 [[ "$DO_RULES" == "true" ]] && hostRules=$(resolve_ep_host "$epRules")
 [[ "$DO_STATE" == "true" ]] && hostState=$(resolve_ep_host "$epState")
 
-# Local addresses for emulator
-if [[ "$USE_LOCALSTACK" == "true" ]]; then
-  funcMainLocal="${funcMain}website.localhost.localstack.cloud:4566"
-  funcALocal="${funcA}website.localhost.localstack.cloud:4566"
-  funcBLocal="${funcB}website.localhost.localstack.cloud:4566"
-  epBasicLocal="${epBasic}.afd.localhost.localstack.cloud:4566"
-  epMultiLocal="${epMulti}.afd.localhost.localstack.cloud:4566"
-  epSpecLocal="${epSpec}.afd.localhost.localstack.cloud:4566"
-  epRulesLocal="${epRules}.afd.localhost.localstack.cloud:4566"
-  epStateLocal="${epState}.afd.localhost.localstack.cloud:4566"
-fi
-
 # -------------------------------
 # Persist environment for cleanup
 # -------------------------------
@@ -449,44 +378,21 @@ echo
 echo "Deployment complete."
 echo "Resource Group: $RESOURCE_GROUP"
 if [[ "$DO_BASIC" == "true" ]]; then
-  if [[ "$USE_LOCALSTACK" == "true" ]]; then
-    echo "[Basic] AFD Local Endpoint:   https://$epBasicLocal/john"
-  else
-    echo "[Basic] AFD Endpoint:         https://$hostBasic/john"
-  fi
+  echo "[Basic] AFD Endpoint:         https://$hostBasic/john"
 fi
 if [[ "$DO_MULTI" == "true" ]]; then
-  if [[ "$USE_LOCALSTACK" == "true" ]]; then
-    echo "[Multi] AFD Local Endpoint:   https://$epMultiLocal/john"
-    echo "       You can inspect responses to see which origin served them (function echoes WEBSITE_HOSTNAME)."
-  else
-    echo "[Multi] AFD Endpoint:         https://$hostMulti/john"
-  fi
+  echo "[Multi] AFD Endpoint:         https://$hostMulti/john"
 fi
 if [[ "$DO_SPEC" == "true" ]]; then
-  if [[ "$USE_LOCALSTACK" == "true" ]]; then
-    echo "[Spec]  AFD Local Endpoint:   https://$epSpecLocal/john  (specific route)"
-    echo "       Also try:              https://$epSpecLocal/jane  (catch-all)"
-  else
-    echo "[Spec]  AFD Endpoint:         https://$hostSpec/john  (specific route)"
-    echo "       Also try:              https://$hostSpec/jane  (catch-all)"
-  fi
+  echo "[Spec]  AFD Endpoint:         https://$hostSpec/john  (specific route)"
+  echo "       Also try:              https://$hostSpec/jane  (catch-all)"
 fi
 if [[ "$DO_RULES" == "true" ]]; then
-  if [[ "$USE_LOCALSTACK" == "true" ]]; then
-    echo "[Rules] AFD Local Endpoint:   https://$epRulesLocal/john"
-    echo "       Expect response header: X-CDN: MSFT (if rules are supported)."
-  else
-    echo "[Rules] AFD Endpoint:         https://$hostRules/john"
-    echo "       Expect response header: X-CDN: MSFT (once propagation completes)."
-  fi
+  echo "[Rules] AFD Endpoint:         https://$hostRules/john"
+  echo "       Expect response header: X-CDN: MSFT (once propagation completes)."
 fi
 if [[ "$DO_STATE" == "true" ]]; then
-  if [[ "$USE_LOCALSTACK" == "true" ]]; then
-    echo "[State] AFD Local Endpoint:   https://$epStateLocal/john"
-  else
-    echo "[State] AFD Endpoint:         https://$hostState/john"
-  fi
+  echo "[State] AFD Endpoint:         https://$hostState/john"
   echo "       To test enabled-state toggle:"
   echo "         az afd endpoint update -g $RESOURCE_GROUP --profile-name $profileName --endpoint-name $epState --enabled-state Disabled"
   echo "         # Then re-enable:"

--- a/samples/web-app-cosmosdb-nosql-api/python/scripts/call-web-app.sh
+++ b/samples/web-app-cosmosdb-nosql-api/python/scripts/call-web-app.sh
@@ -68,7 +68,7 @@ get_docker_container_port_mapping() {
 call_web_app() {
 	# Get the web app name
 	echo "Getting web app name..."
-	web_app_name=$(azlocal webapp list --query '[0].name' --output tsv)
+	web_app_name=$(az webapp list --query '[0].name' --output tsv)
 
 	if [ -n "$web_app_name" ]; then
 		echo "Web app [$web_app_name] successfully retrieved."
@@ -79,7 +79,7 @@ call_web_app() {
 
 	# Get the resource group name
 	echo "Getting resource group name for web app [$web_app_name]..."
-	resource_group_name=$(azlocal webapp list --query '[0].resourceGroup' --output tsv)
+	resource_group_name=$(az webapp list --query '[0].resourceGroup' --output tsv)
 
 	if [ -n "$resource_group_name" ]; then
 		echo "Resource group [$resource_group_name] successfully retrieved."
@@ -90,7 +90,7 @@ call_web_app() {
 
 	# Get the the default host name of the web app
 	echo "Getting the default host name of the web app [$web_app_name]..."
-	app_host_name=$(azlocal webapp show \
+	app_host_name=$(az webapp show \
 		--name "$web_app_name" \
 		--resource-group "$resource_group_name" \
 		--query 'defaultHostName' \

--- a/samples/web-app-cosmosdb-nosql-api/python/scripts/deploy.sh
+++ b/samples/web-app-cosmosdb-nosql-api/python/scripts/deploy.sh
@@ -18,21 +18,21 @@ AZURECOSMOSDB_CONTAINERNAME="activities_${RANDOM_SUFFIX}"
 AURECOSMOSDB_PARTITION_KEY="/partitionKey"
 
 # Start azure CLI local mode session
-azlocal login
+az login
 
 # Change the current directory to the script's directory
 #cd "$CURRENT_DIR" || exit
 
 # Validates if the resource group exists in the subscription, if not creates it
 echo "Checking if resource group [$RESOURCE_GROUP_NAME] exists..."
-azlocal group show --name $RESOURCE_GROUP_NAME &>/dev/null
+az group show --name $RESOURCE_GROUP_NAME &>/dev/null
 
 if [[ $? != 0 ]]; then
 	echo "No resource group [$RESOURCE_GROUP_NAME] exists"
 	echo "Creating resource group [$RESOURCE_GROUP_NAME]..."
 
 	# Create the resource group
-    azlocal group create \
+    az group create \
         --name $RESOURCE_GROUP_NAME \
         --location $LOCATION \
         --only-show-errors 1> /dev/null \
@@ -48,7 +48,7 @@ else
 fi
 
 echo "Create CosmosDB NoSQL Account"
-    export AZURECOSMOSDB_ENDPOINT=$(azlocal cosmosdb create \
+    export AZURECOSMOSDB_ENDPOINT=$(az cosmosdb create \
         --resource-group $RESOURCE_GROUP_NAME \
         --name $WEB_APP_NAME \
         --locations regionName=$LOCATION \
@@ -59,13 +59,13 @@ echo "Account created"
 echo "AZURECOSMOSDB_ENDPOINT set to $AZURECOSMOSDB_ENDPOINT"
 
 echo "Create CosmosDB NoSQL Database"
-azlocal cosmosdb sql database create \
+az cosmosdb sql database create \
     --resource-group $RESOURCE_GROUP_NAME \
     --name $AZURECOSMOSDB_DATABASENAME \
     --account-name $WEB_APP_NAME
 
 echo "Create CosmosDB NoSQL Container"
-azlocal cosmosdb sql container create \
+az cosmosdb sql container create \
     --resource-group $RESOURCE_GROUP_NAME \
     --account-name $WEB_APP_NAME \
     --database-name $AZURECOSMOSDB_DATABASENAME \
@@ -74,7 +74,7 @@ azlocal cosmosdb sql container create \
     --throughput 400
 
 echo "Fetching DB Account primary master key"
-export AZURECOSMOSDB_PRIMARY_KEY=$(azlocal cosmosdb keys list \
+export AZURECOSMOSDB_PRIMARY_KEY=$(az cosmosdb keys list \
         --resource-group $RESOURCE_GROUP_NAME \
         --name $WEB_APP_NAME \
         --query "primaryMasterKey" \
@@ -82,15 +82,15 @@ export AZURECOSMOSDB_PRIMARY_KEY=$(azlocal cosmosdb keys list \
 echo "Primary master key is $AZURECOSMOSDB_PRIMARY_KEY"
 
 echo "Creating App service"
-azlocal appservice plan create --name $WEB_APP_NAME --resource-group $RESOURCE_GROUP_NAME --sku B1 --is-linux
+az appservice plan create --name $WEB_APP_NAME --resource-group $RESOURCE_GROUP_NAME --sku B1 --is-linux
 echo "App service created"
 
 echo "Creating Web App"
-azlocal webapp create --name $WEB_APP_NAME --resource-group $RESOURCE_GROUP_NAME --plan $WEB_APP_NAME --runtime PYTHON:3.13
+az webapp create --name $WEB_APP_NAME --resource-group $RESOURCE_GROUP_NAME --plan $WEB_APP_NAME --runtime PYTHON:3.13
 echo "Web App created"
 
 echo "Configure appsettings environment variables"
-azlocal webapp config appsettings set \
+az webapp config appsettings set \
     --resource-group $RESOURCE_GROUP_NAME \
     --name $WEB_APP_NAME \
     --settings AZURECOSMOSDB_ENDPOINT=$AZURECOSMOSDB_ENDPOINT \
@@ -100,7 +100,7 @@ azlocal webapp config appsettings set \
 
 # Print the application settings of the web app
 echo "Retrieving application settings for web app [$WEB_APP_NAME]..."
-azlocal webapp config appsettings list \
+az webapp config appsettings list \
 	--resource-group $RESOURCE_GROUP_NAME \
 	--name $WEB_APP_NAME
 
@@ -118,8 +118,7 @@ zip -r "$ZIPFILE" app.py cosmosdb_client.py static templates requirements.txt
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."
-echo "Using azlocal webapp deploy command for LocalStack emulator environment."
-azlocal webapp deploy \
+az webapp deploy \
     --resource-group $RESOURCE_GROUP_NAME \
     --name $WEB_APP_NAME \
     --src-path ${ZIPFILE} \


### PR DESCRIPTION
## Motivation

Follow-up to #64 (Replace azlocal with az). Function App and Front Door, ACI and Blob Storage, and Web App and CosmosDB for NoSQL API has now az instead of azlocal. This PR ensures all sample apps consistently use az instead of azlocal.

## Changes

- ACI Blob Storage (samples/aci-blob-storage/python/): Removed unused AZ="azlocal" / AZ="az" branching blocks from terraform/deploy.sh, scripts/validate.sh, and scripts/cleanup.sh (the $AZ variable was defined but never referenced)
- Web App CosmosDB NoSQL API (samples/web-app-cosmosdb-nosql-api/python/scripts/): Replaced all hardcoded azlocal CLI calls with az in deploy.sh and call-web-app.sh
- Function App Front Door (samples/function-app-front-door/python/scripts/): Removed --use-localstack flag and azlocal interception lifecycle from deploy_all.sh and cleanup_all.sh. The script now auto-detects LocalStack via az account show --query environmentName and prints local endpoints accordingly
- run-samples.sh: Removed --use-localstack flag from the front-door sample entry to match the updated script

## Tests

- Ran the Function App and Front Door sample locally against LocalStack — deployment completes successfully and local endpoints are printed correctly


## Related

- #64 — Replace azlocal with az
