### PR TITLE
Added azlocal start-interception to all README files

### DIFF
--- a/docs/LOCALSTACK.md
+++ b/docs/LOCALSTACK.md
@@ -28,8 +28,15 @@ You can start the Azure emulator using one of the following methods:
 Make sure the `localstack` CLI is installed (`pip install localstack` or `brew install localstack/tap/localstack`).
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 This:

--- a/samples/aci-blob-storage/python/README.md
+++ b/samples/aci-blob-storage/python/README.md
@@ -27,13 +27,12 @@ The following diagram illustrates the architecture of the solution:
 ## Quick Start
 
 ```bash
-# Start LocalStack Azure
+# Start the LocalStack Azure emulator
 IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
 localstack wait -t 60
 
-# Login
-azlocal login
-azlocal start_interception
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 
 # Deploy all services
 cd python

--- a/samples/function-app-front-door/python/README.md
+++ b/samples/function-app-front-door/python/README.md
@@ -62,12 +62,26 @@ The following diagrams visualize each scenario provisioned by `deploy_all.sh`. T
 
 ## Quick Start
 
-1. **Deploy against real Azure** (eastus by default):
+1. 
+
+## Quick Start
+
+1. **Start the LocalStack Azure emulator**
+  ```bash
+  # Start the LocalStack Azure emulator
+  IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+  localstack wait -t 60
+
+  # Route all Azure CLI calls to the LocalStack Azure emulator
+  azlocal start-interception
+  ```
+
+2. **Deploy against real Azure** (eastus by default):
    ```bash
    bash ./scripts/deploy_all.sh --name-prefix mydemo
    ```
 
-2. **Deploy against LocalStack emulator**:
+3. **Deploy against LocalStack emulator**:
    ```bash
    bash ./scripts/deploy_all.sh --name-prefix mydemo --use-localstack
    ```

--- a/samples/function-app-managed-identity/python/README.md
+++ b/samples/function-app-managed-identity/python/README.md
@@ -62,8 +62,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/function-app-managed-identity/python/bicep/README.md
+++ b/samples/function-app-managed-identity/python/bicep/README.md
@@ -83,8 +83,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/function-app-managed-identity/python/scripts/README.md
+++ b/samples/function-app-managed-identity/python/scripts/README.md
@@ -60,8 +60,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/function-app-managed-identity/python/terraform/README.md
+++ b/samples/function-app-managed-identity/python/terraform/README.md
@@ -88,8 +88,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/function-app-service-bus/dotnet/README.md
+++ b/samples/function-app-service-bus/dotnet/README.md
@@ -64,9 +64,16 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
-   ```
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
+```
 
 Deploy the application to LocalStack for Azure using one of these methods:
 

--- a/samples/function-app-service-bus/dotnet/bicep/README.md
+++ b/samples/function-app-service-bus/dotnet/bicep/README.md
@@ -101,8 +101,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/function-app-service-bus/dotnet/scripts/README.md
+++ b/samples/function-app-service-bus/dotnet/scripts/README.md
@@ -70,8 +70,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/function-app-service-bus/dotnet/terraform/README.md
+++ b/samples/function-app-service-bus/dotnet/terraform/README.md
@@ -106,8 +106,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/function-app-storage-http/dotnet/terraform/README.md
+++ b/samples/function-app-storage-http/dotnet/terraform/README.md
@@ -83,8 +83,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/servicebus/java/README.md
+++ b/samples/servicebus/java/README.md
@@ -37,8 +37,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/servicebus/java/bicep/README.md
+++ b/samples/servicebus/java/bicep/README.md
@@ -75,8 +75,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/servicebus/java/scripts/README.md
+++ b/samples/servicebus/java/scripts/README.md
@@ -58,8 +58,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/servicebus/java/terraform/README.md
+++ b/samples/servicebus/java/terraform/README.md
@@ -81,8 +81,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/web-app-cosmosdb-mongodb-api/python/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/README.md
@@ -47,9 +47,16 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
-   ```
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
+```
 
 Deploy the application to LocalStack for Azure using one of these methods:
 

--- a/samples/web-app-cosmosdb-mongodb-api/python/bicep/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/bicep/README.md
@@ -88,8 +88,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/web-app-cosmosdb-mongodb-api/python/scripts/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/scripts/README.md
@@ -73,8 +73,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/README.md
@@ -93,8 +93,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/web-app-cosmosdb-nosql-api/python/README.md
+++ b/samples/web-app-cosmosdb-nosql-api/python/README.md
@@ -30,9 +30,16 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
-   ```
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
+```
 
 Deploy the application to LocalStack for Azure using:
 

--- a/samples/web-app-cosmosdb-nosql-api/python/scripts/README.md
+++ b/samples/web-app-cosmosdb-nosql-api/python/scripts/README.md
@@ -35,8 +35,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-managed-identity/python/README.md
+++ b/samples/web-app-managed-identity/python/README.md
@@ -58,8 +58,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/web-app-managed-identity/python/bicep/README.md
+++ b/samples/web-app-managed-identity/python/bicep/README.md
@@ -63,8 +63,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/web-app-managed-identity/python/scripts/README.md
+++ b/samples/web-app-managed-identity/python/scripts/README.md
@@ -79,8 +79,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-managed-identity/python/terraform/README.md
+++ b/samples/web-app-managed-identity/python/terraform/README.md
@@ -77,8 +77,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/web-app-sql-database/python/README.md
+++ b/samples/web-app-sql-database/python/README.md
@@ -61,8 +61,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/web-app-sql-database/python/bicep/README.md
+++ b/samples/web-app-sql-database/python/bicep/README.md
@@ -49,8 +49,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/web-app-sql-database/python/scripts/README.md
+++ b/samples/web-app-sql-database/python/scripts/README.md
@@ -49,8 +49,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-sql-database/python/terraform/README.md
+++ b/samples/web-app-sql-database/python/terraform/README.md
@@ -73,8 +73,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:


### PR DESCRIPTION
## Motivation
In all the `README.md` files we need to explain how to: 

- Get an authentication token
- Start the emulator
- Route all the Azure CLI calls to the emulator
<!--
Elaborate the background and intent for raising this PR.
-->

## Changes
Added the following snippet to all the `README.md` files:

```bash
# Set the authentication token
export LOCALSTACK_AUTH_TOKEN=<your_auth_token>

# Start the LocalStack Azure emulator
IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
localstack wait -t 60

# Route all Azure CLI calls to the LocalStack Azure emulator
azlocal start-interception
```

<!--
Summarise the changes proposed in the PR.
-->

## Tests

<!--
Optional: How are the proposed changes tested?
-->

## Related

<!--
Optional: Links to related issues and references (e.g., Linear IDs).
-->
