### PR TITLE
Fix Web Apps + SQL Server Demo

### DIFF
--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
-    runs-on: github-ubuntu2204-amd64-4
+    runs-on: ubuntu-22.04
 
     env:
       IMAGE_NAME: localstack/localstack-azure-alpha

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -163,8 +163,10 @@ jobs:
         # Required for the 'web-app-sql-database' sample which uses 'sqlcmd' to
         # initialize and verify the database schema in the local emulator.
         run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
-          curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          if [ ! -f /etc/apt/sources.list.d/mssql-release.list ]; then
+            curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+            curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          fi
           sudo apt-get update
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18
           echo "/opt/mssql-tools18/bin" >> $GITHUB_PATH

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -163,10 +163,9 @@ jobs:
         # Required for the 'web-app-sql-database' sample which uses 'sqlcmd' to
         # initialize and verify the database schema in the local emulator.
         run: |
-          if [ ! -f /etc/apt/sources.list.d/mssql-release.list ]; then
-            curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
-            curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
-          fi
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+          curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
           sudo apt-get update
           sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18 mssql-tools18
           echo "/opt/mssql-tools18/bin" >> $GITHUB_PATH

--- a/docs/LOCALSTACK.md
+++ b/docs/LOCALSTACK.md
@@ -28,8 +28,15 @@ You can start the Azure emulator using one of the following methods:
 Make sure the `localstack` CLI is installed (`pip install localstack` or `brew install localstack/tap/localstack`).
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 This:

--- a/samples/aci-blob-storage/python/README.md
+++ b/samples/aci-blob-storage/python/README.md
@@ -27,13 +27,12 @@ The following diagram illustrates the architecture of the solution:
 ## Quick Start
 
 ```bash
-# Start LocalStack Azure
+# Start the LocalStack Azure emulator
 IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
 localstack wait -t 60
 
-# Login
-azlocal login
-azlocal start_interception
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 
 # Deploy all services
 cd python

--- a/samples/function-app-front-door/python/README.md
+++ b/samples/function-app-front-door/python/README.md
@@ -62,12 +62,26 @@ The following diagrams visualize each scenario provisioned by `deploy_all.sh`. T
 
 ## Quick Start
 
-1. **Deploy against real Azure** (eastus by default):
+1. 
+
+## Quick Start
+
+1. **Start the LocalStack Azure emulator**
+  ```bash
+  # Start the LocalStack Azure emulator
+  IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+  localstack wait -t 60
+
+  # Route all Azure CLI calls to the LocalStack Azure emulator
+  azlocal start-interception
+  ```
+
+2. **Deploy against real Azure** (eastus by default):
    ```bash
    bash ./scripts/deploy_all.sh --name-prefix mydemo
    ```
 
-2. **Deploy against LocalStack emulator**:
+3. **Deploy against LocalStack emulator**:
    ```bash
    bash ./scripts/deploy_all.sh --name-prefix mydemo --use-localstack
    ```

--- a/samples/function-app-managed-identity/python/README.md
+++ b/samples/function-app-managed-identity/python/README.md
@@ -62,8 +62,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/function-app-managed-identity/python/bicep/README.md
+++ b/samples/function-app-managed-identity/python/bicep/README.md
@@ -83,8 +83,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/function-app-managed-identity/python/scripts/README.md
+++ b/samples/function-app-managed-identity/python/scripts/README.md
@@ -60,8 +60,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/function-app-managed-identity/python/terraform/README.md
+++ b/samples/function-app-managed-identity/python/terraform/README.md
@@ -88,8 +88,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/function-app-service-bus/dotnet/README.md
+++ b/samples/function-app-service-bus/dotnet/README.md
@@ -64,9 +64,16 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
-   ```
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
+```
 
 Deploy the application to LocalStack for Azure using one of these methods:
 

--- a/samples/function-app-service-bus/dotnet/bicep/README.md
+++ b/samples/function-app-service-bus/dotnet/bicep/README.md
@@ -101,8 +101,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/function-app-service-bus/dotnet/scripts/README.md
+++ b/samples/function-app-service-bus/dotnet/scripts/README.md
@@ -70,8 +70,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/function-app-service-bus/dotnet/terraform/README.md
+++ b/samples/function-app-service-bus/dotnet/terraform/README.md
@@ -106,8 +106,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/function-app-storage-http/dotnet/terraform/README.md
+++ b/samples/function-app-storage-http/dotnet/terraform/README.md
@@ -83,8 +83,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/servicebus/java/README.md
+++ b/samples/servicebus/java/README.md
@@ -37,8 +37,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/servicebus/java/bicep/README.md
+++ b/samples/servicebus/java/bicep/README.md
@@ -75,8 +75,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/servicebus/java/scripts/README.md
+++ b/samples/servicebus/java/scripts/README.md
@@ -58,8 +58,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/servicebus/java/terraform/README.md
+++ b/samples/servicebus/java/terraform/README.md
@@ -81,8 +81,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/web-app-cosmosdb-mongodb-api/python/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/README.md
@@ -47,9 +47,16 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
-   ```
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
+```
 
 Deploy the application to LocalStack for Azure using one of these methods:
 

--- a/samples/web-app-cosmosdb-mongodb-api/python/bicep/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/bicep/README.md
@@ -88,8 +88,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/web-app-cosmosdb-mongodb-api/python/scripts/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/scripts/README.md
@@ -73,8 +73,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/README.md
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/README.md
@@ -93,8 +93,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/web-app-cosmosdb-nosql-api/python/README.md
+++ b/samples/web-app-cosmosdb-nosql-api/python/README.md
@@ -30,9 +30,16 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
-   ```
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
+```
 
 Deploy the application to LocalStack for Azure using:
 

--- a/samples/web-app-cosmosdb-nosql-api/python/scripts/README.md
+++ b/samples/web-app-cosmosdb-nosql-api/python/scripts/README.md
@@ -35,8 +35,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-managed-identity/python/README.md
+++ b/samples/web-app-managed-identity/python/README.md
@@ -58,8 +58,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/web-app-managed-identity/python/bicep/README.md
+++ b/samples/web-app-managed-identity/python/bicep/README.md
@@ -63,8 +63,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/web-app-managed-identity/python/scripts/README.md
+++ b/samples/web-app-managed-identity/python/scripts/README.md
@@ -79,8 +79,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-managed-identity/python/terraform/README.md
+++ b/samples/web-app-managed-identity/python/terraform/README.md
@@ -77,8 +77,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/web-app-sql-database/python/README.md
+++ b/samples/web-app-sql-database/python/README.md
@@ -61,8 +61,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator by running:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Deploy the application to LocalStack for Azure using one of these methods:

--- a/samples/web-app-sql-database/python/bicep/README.md
+++ b/samples/web-app-sql-database/python/bicep/README.md
@@ -49,8 +49,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `bicep` folder:

--- a/samples/web-app-sql-database/python/bicep/deploy.sh
+++ b/samples/web-app-sql-database/python/bicep/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Variables
-PREFIX='cayado'
+PREFIX='local'
 SUFFIX='test'
 TEMPLATE="main.bicep"
 PARAMETERS="main.bicepparam"

--- a/samples/web-app-sql-database/python/bicep/deploy.sh
+++ b/samples/web-app-sql-database/python/bicep/deploy.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Variables
-PREFIX='local'
+PREFIX='cayado'
 SUFFIX='test'
 TEMPLATE="main.bicep"
 PARAMETERS="main.bicepparam"
-RESOURCE_GROUP_NAME="$PREFIX-webapp-sql-rg"
+RESOURCE_GROUP_NAME="$PREFIX-rg"
 LOCATION="westeurope"
 VALIDATE_TEMPLATE=1
 USE_WHAT_IF=0
@@ -295,7 +295,7 @@ fi
 
 # Create the zip package of the web app
 echo "Creating zip package of the web app..."
-zip -r "$ZIPFILE" app.py activities.py database.py static templates requirements.txt
+zip -r "$ZIPFILE" app.py activities.py certificates.py database.py static templates requirements.txt
 
 # Deploy the web app
 echo "Deploying web app [$WEB_APP_NAME] with zip file [$ZIPFILE]..."

--- a/samples/web-app-sql-database/python/bicep/main.bicep
+++ b/samples/web-app-sql-database/python/bicep/main.bicep
@@ -323,6 +323,7 @@ var sqlServerName = '${prefix}-sqlserver-${suffix}'
 var webAppName = '${prefix}-webapp-${suffix}'
 var appServicePlanName = '${prefix}-app-service-plan-${suffix}'
 var keyVaultName = '${prefix}-kv-${suffix}'
+var certificateName = '${prefix}-cert-${suffix}'
 var sqlConnectionStringSecretName = 'sql-connection-string'
 var identity = {
     type: 'SystemAssigned'
@@ -478,6 +479,7 @@ resource configAppSettings 'Microsoft.Web/sites/config@2024-11-01' = {
     KEY_VAULT_NAME: keyVaultName
     SECRET_NAME: sqlConnectionStringSecretName
     LOGIN_NAME: username
+    KEYVAULT_URI: keyVault.properties.vaultUri
   }
 }
 

--- a/samples/web-app-sql-database/python/bicep/main.bicep
+++ b/samples/web-app-sql-database/python/bicep/main.bicep
@@ -323,8 +323,7 @@ var sqlServerName = '${prefix}-sqlserver-${suffix}'
 var webAppName = '${prefix}-webapp-${suffix}'
 var appServicePlanName = '${prefix}-app-service-plan-${suffix}'
 var keyVaultName = '${prefix}-kv-${suffix}'
-var certificateName = '${prefix}-cert-${suffix}'
-var sqlConnectionStringSecretName = 'sql-connection-string'
+var sqlConnectionStringSecretName = '${prefix}-secret-${suffix}'
 var identity = {
     type: 'SystemAssigned'
   }

--- a/samples/web-app-sql-database/python/scripts/README.md
+++ b/samples/web-app-sql-database/python/scripts/README.md
@@ -49,8 +49,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `scripts` folder:

--- a/samples/web-app-sql-database/python/scripts/validate.sh
+++ b/samples/web-app-sql-database/python/scripts/validate.sh
@@ -1,44 +1,59 @@
 #!/bin/bash
 
 # Variables
-# Check resource group
-az group show \
---name local-rg \
---output table
+PREFIX='local'
+SUFFIX='test'
+RESOURCE_GROUP_NAME="${PREFIX}-rg"
+SQL_SERVER_NAME="${PREFIX}-sqlserver-${SUFFIX}"
+SQL_DATABASE_NAME='PlannerDB'
+WEB_APP_NAME="${PREFIX}-webapp-${SUFFIX}"
+KEY_VAULT_NAME="${PREFIX}-kv-${SUFFIX}"
+SECRET_NAME="${PREFIX}-secret-${SUFFIX}"
 
-# List resources
-az resource list \
---resource-group local-rg \
+# Check resource group
+echo -e "[$RESOURCE_GROUP_NAME] resource group:\n"
+az group show \
+--name "$RESOURCE_GROUP_NAME" \
 --output table
 
 # Check Azure Web App
+echo -e "\n[$WEB_APP_NAME] web app:\n"
 az webapp show \
---name local-webapp-test \
---resource-group local-rg \
+--name "$WEB_APP_NAME" \
+--resource-group "$RESOURCE_GROUP_NAME" \
+--query "{name:name, state:state, defaultHostName:defaultHostName}" \
 --output table
 
 # Check Azure SQL Server
+echo -e "\n[$SQL_SERVER_NAME] SQL server:\n"
 az sql server show \
---name local-sqlserver-test \
---resource-group local-rg \
+--name "$SQL_SERVER_NAME" \
+--resource-group "$RESOURCE_GROUP_NAME" \
 --output table
 
 # Check Azure SQL Database
+echo -e "\n[$SQL_DATABASE_NAME] SQL database:\n"
 az sql db show \
---name PlannerDB \
---server local-sqlserver-test \
---resource-group local-rg \
+--name "$SQL_DATABASE_NAME" \
+--server "$SQL_SERVER_NAME" \
+--resource-group "$RESOURCE_GROUP_NAME" \
 --output table
 
 # Check Azure Key Vault
+echo -e "\n[$KEY_VAULT_NAME] Key Vault:\n"
 az keyvault show \
---name local-kv-test \
---resource-group local-rg \
+--name "$KEY_VAULT_NAME" \
+--resource-group "$RESOURCE_GROUP_NAME" \
 --output table
 
 # Check Key Vault secret
+echo -e "\n[$SECRET_NAME] Key Vault secret:\n"
 az keyvault secret show \
---vault-name local-kv-test \
---name local-secret-test \
+--vault-name "$KEY_VAULT_NAME" \
+--name "$SECRET_NAME" \
 --query "{name:name, enabled:attributes.enabled, created:attributes.created}" \
 --output table
+
+# Print the list of resources in the resource group
+echo -e "\nListing resources in resource group [$RESOURCE_GROUP_NAME]...\n"
+az resource list --resource-group "$RESOURCE_GROUP_NAME" --output table 

--- a/samples/web-app-sql-database/python/src/requirements.txt
+++ b/samples/web-app-sql-database/python/src/requirements.txt
@@ -1,8 +1,8 @@
-Flask==3.1.0
-azure-identity==1.25.1
+Flask==3.1.3
+azure-identity==1.25.3
 pyodbc==5.3.0
-gunicorn==23.0.0
-python-dotenv==1.1.1
-azure-keyvault-secrets
-azure-keyvault-certificates
-cryptography
+gunicorn==25.3.0
+python-dotenv==1.2.2
+azure-keyvault-secrets==4.10.0
+azure-keyvault-certificates==4.10.0
+cryptography==46.0.7

--- a/samples/web-app-sql-database/python/terraform/README.md
+++ b/samples/web-app-sql-database/python/terraform/README.md
@@ -73,8 +73,15 @@ docker pull localstack/localstack-azure-alpha
 Start the LocalStack Azure emulator using the localstack CLI, execute the following command:
 
 ```bash
+# Set the authentication token
 export LOCALSTACK_AUTH_TOKEN=<your_auth_token>
-IMAGE_NAME=localstack/localstack-azure-alpha localstack start
+
+# Start the LocalStack Azure emulator
+IMAGE_NAME=localstack/localstack-azure-alpha localstack start -d
+localstack wait -t 60
+
+# Route all Azure CLI calls to the LocalStack Azure emulator
+azlocal start-interception
 ```
 
 Navigate to the `terraform` folder:

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.14.0"
+      version = "=4.25.0"
     }
   }
 }

--- a/samples/web-app-sql-database/python/terraform/terraform.tfvars
+++ b/samples/web-app-sql-database/python/terraform/terraform.tfvars
@@ -1,2 +1,2 @@
 location            = "westeurope"
-python_version      = "3.12"
+python_version      = "3.13"

--- a/samples/web-app-sql-database/python/terraform/variables.tf
+++ b/samples/web-app-sql-database/python/terraform/variables.tf
@@ -281,6 +281,7 @@ variable "python_version" {
 
   validation {
     condition = contains([
+      "3.13",
       "3.12",
       "3.11",
       "3.10",


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

This pull request fixes the Bicep and Terraform deployment for the Azure Web App + Azure SQL Database sample. 

## Changes

- `terraform.tfvars` and `variables.sh`: Bumped up the python version used by the web app from `3.12` to `3.13`.
- `bicep/deploy.sh`: Included the `certificates.py` module in the zip file used to deploy the web app.
- `scripts/validate.sh`

## Tests

The sample was tested against Azure and using the latest version of the LocalStack for Azure emulator.
