### PR TITLE
Tests: Only purge docker when explicitly requested

### DIFF
--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -208,6 +208,7 @@ jobs:
           SHARD: ${{ matrix.shard }}
           SPLITS: ${{ matrix.splits }}
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.TEST_LOCALSTACK_AUTH_TOKEN }}
+          PURGE_DOCKER: "1"
 
       - name: Get LocalStack Logs
         # Captured on failure or success to provide a detailed audit trail of the emulator's activity.

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -27,6 +27,8 @@ if [ -f .env ]; then
   set +a
 fi
 
+PURGE_DOCKER="${PURGE_DOCKER:-0}"
+
 # 1. Define Samples (placed before tool checks so --list works without dependencies)
 SAMPLES=(
   "samples/servicebus/java|bash scripts/deploy.sh"
@@ -203,10 +205,12 @@ for (( i=START; i<START+COUNT; i++ )); do
     fi
   fi
 
-  # Cleanup Docker resources after each test to free up disk space
-  echo "Cleaning up Docker resources..."
-  docker system prune -af --volumes || true
-  echo ""
+  if [[ ${PURGE_DOCKER} == "1" ]]; then
+    # Cleanup Docker resources after each test to free up disk space
+    echo "Cleaning up Docker resources..."
+    docker system prune -af --volumes || true
+    echo ""
+  fi
 done
 
 echo "All samples completed successfully!"


### PR DESCRIPTION
## Motivation

Purging all Docker resources may not always be required - i.e. when running locally, you explicitly do **_not_** want this, as it also removes all images/volumes/etc not managed by the Emulator.

With this change, the `docker purge` command is only executed in the CI, where it doesn't matter - or on demand, if the user knows what they're doing.