### PR TITLE
Add PostgreSQL flexible server samples to run-samples script

### DIFF
--- a/run-samples.sh
+++ b/run-samples.sh
@@ -40,6 +40,7 @@ SAMPLES=(
   "samples/web-app-managed-identity/python|bash scripts/user-assigned.sh|bash scripts/validate.sh && bash scripts/call-web-app.sh"
   "samples/web-app-sql-database/python|bash scripts/deploy.sh|bash scripts/validate.sh && bash scripts/get-web-app-url.sh"
   "samples/web-app-mysql-flexible-server/python|bash scripts/deploy.sh|bash scripts/validate.sh && bash scripts/call-web-app.sh"
+  "samples/web-app-postgresql-flexible-server/python|bash scripts/deploy.sh|bash scripts/validate.sh && bash scripts/call-web-app.sh"
   "samples/web-app-custom-image/python|bash scripts/deploy.sh|bash scripts/validate.sh && bash scripts/call-web-app.sh"
   "samples/aci-blob-storage/python|bash scripts/deploy.sh|bash scripts/validate.sh"
 )
@@ -54,6 +55,7 @@ TERRAFORM_SAMPLES=(
   "samples/web-app-managed-identity/python/terraform|bash deploy.sh"
   "samples/web-app-sql-database/python/terraform|bash deploy.sh"
   "samples/web-app-mysql-flexible-server/python/terraform|bash deploy.sh"
+  "samples/web-app-postgresql-flexible-server/python/terraform|bash deploy.sh"
   "samples/aci-blob-storage/python/terraform|bash deploy.sh"
 )
 
@@ -67,6 +69,7 @@ BICEP_SAMPLES=(
   "samples/web-app-cosmosdb-mongodb-api/python/bicep|bash deploy.sh"
   "samples/web-app-managed-identity/python/bicep|bash deploy.sh"
   "samples/web-app-mysql-flexible-server/python/bicep|bash deploy.sh"
+  "samples/web-app-postgresql-flexible-server/python/bicep|bash deploy.sh"
   "samples/aci-blob-storage/python/bicep|bash deploy.sh"
 )
 

--- a/samples/web-app-postgresql-flexible-server/python/scripts/deploy.sh
+++ b/samples/web-app-postgresql-flexible-server/python/scripts/deploy.sh
@@ -146,9 +146,9 @@ echo "PostgreSQL host = $POSTGRES_FQDN, port = $POSTGRES_PORT"
 # Check if the server-level firewall rule already exists
 echo "Checking if [$FIREWALL_RULE_NAME] firewall rule already exists on the [$POSTGRES_SERVER_NAME] PostgreSQL flexible server..."
 az postgres flexible-server firewall-rule show \
-	--name $POSTGRES_SERVER_NAME \
+	--server-name $POSTGRES_SERVER_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
-	--rule-name $FIREWALL_RULE_NAME \
+	--name $FIREWALL_RULE_NAME \
 	--only-show-errors &>/dev/null
 
 if [[ $? != 0 ]]; then
@@ -157,9 +157,9 @@ if [[ $? != 0 ]]; then
 
 	# Create a permissive firewall rule so the deploy machine can run the psql bootstrap
 	az postgres flexible-server firewall-rule create \
-		--name $POSTGRES_SERVER_NAME \
+		--server-name $POSTGRES_SERVER_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
-		--rule-name $FIREWALL_RULE_NAME \
+		--name $FIREWALL_RULE_NAME \
 		--start-ip-address "0.0.0.0" \
 		--end-ip-address "255.255.255.255" \
 		--only-show-errors 1>/dev/null
@@ -179,7 +179,7 @@ echo "Checking if [$POSTGRES_DATABASE_NAME] database already exists on the [$POS
 az postgres flexible-server db show \
 	--server-name $POSTGRES_SERVER_NAME \
 	--resource-group $RESOURCE_GROUP_NAME \
-	--database-name $POSTGRES_DATABASE_NAME \
+	--name $POSTGRES_DATABASE_NAME \
 	--only-show-errors &>/dev/null
 
 if [[ $? != 0 ]]; then
@@ -190,7 +190,7 @@ if [[ $? != 0 ]]; then
 	az postgres flexible-server db create \
 		--server-name $POSTGRES_SERVER_NAME \
 		--resource-group $RESOURCE_GROUP_NAME \
-		--database-name $POSTGRES_DATABASE_NAME \
+		--name $POSTGRES_DATABASE_NAME \
 		--charset UTF8 \
 		--collation en_US.utf8 \
 		--only-show-errors 1>/dev/null

--- a/samples/web-app-postgresql-flexible-server/python/scripts/deploy.sh
+++ b/samples/web-app-postgresql-flexible-server/python/scripts/deploy.sh
@@ -85,7 +85,7 @@ if [[ $? != 0 ]]; then
 		--admin-user $PG_ADMIN_USER \
 		--admin-password "$PG_ADMIN_PASSWORD" \
 		--public-access Enabled \
-		--high-availability Disabled \
+		--zonal-resiliency Disabled \
 		--yes \
 		--tags environment=test iac=az-cli \
 		--only-show-errors 1>/dev/null

--- a/samples/web-app-postgresql-flexible-server/python/scripts/validate.sh
+++ b/samples/web-app-postgresql-flexible-server/python/scripts/validate.sh
@@ -55,7 +55,7 @@ echo -e "\n[$POSTGRES_DATABASE_NAME] PostgreSQL database:\n"
 az postgres flexible-server db show \
 	--server-name "$POSTGRES_SERVER_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
-	--database-name "$POSTGRES_DATABASE_NAME" \
+	--name "$POSTGRES_DATABASE_NAME" \
 	--query '{Name:name,ResourceGroup:resourceGroup,Charset:charset,Collation:collation}' \
 	--output table \
 	--only-show-errors
@@ -63,9 +63,9 @@ az postgres flexible-server db show \
 # Check PostgreSQL firewall rule
 echo -e "\n[$FIREWALL_RULE_NAME] PostgreSQL firewall rule:\n"
 az postgres flexible-server firewall-rule show \
-	--name "$POSTGRES_SERVER_NAME" \
+	--server-name "$POSTGRES_SERVER_NAME" \
 	--resource-group "$RESOURCE_GROUP_NAME" \
-	--rule-name "$FIREWALL_RULE_NAME" \
+	--name "$FIREWALL_RULE_NAME" \
 	--output table \
 	--only-show-errors
 


### PR DESCRIPTION
## Motivation

Add the PostgreSQL flexible server sample to the CI matrix (`run-samples.sh`), since
only MySQL was being tested before.

## Changes

Wire the PostgreSQL sample (scripts, Terraform, Bicep) into `run-samples.sh`, and update
its `az postgres flexible-server` commands, which were outdated and broke under Azure CLI 2.86.0.
