### PR TITLE
Show the real alert total and make dashboard updates visible

### DIFF
--- a/samples/eventhubs/python/README.md
+++ b/samples/eventhubs/python/README.md
@@ -71,7 +71,8 @@ schema registry.
   `LOCALSTACK_AUTH_TOKEN`
 - [Docker](https://docs.docker.com/get-docker/)
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) and
-  [azlocal](https://pypi.org/project/azlocal/) (`pip install azlocal`)
+  [lstk](https://github.com/localstack/lstk) (`brew install localstack/tap/lstk` or
+  `npm install -g @localstack/lstk`)
 - Python 3.12+ with `src/producers/requirements.txt` installed
 - `jq` and `zip`
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) or the Bicep CLI, for
@@ -86,7 +87,7 @@ IMAGE_NAME=localstack/localstack-azure localstack start -d
 localstack wait -t 120
 
 # Route the Azure CLI to the emulator
-azlocal start-interception
+lstk az start-interception
 
 cd samples/eventhubs/python
 pip install -r src/producers/requirements.txt

--- a/samples/eventhubs/python/bicep/README.md
+++ b/samples/eventhubs/python/bicep/README.md
@@ -5,7 +5,7 @@ application code with the Azure CLI.
 
 ## Prerequisites
 
-- The LocalStack Azure emulator is running and `azlocal start-interception` has been run.
+- The LocalStack Azure emulator is running and `lstk az start-interception` has been run.
 - The Bicep CLI (`az bicep install`) and `jq` are available.
 
 ## Usage

--- a/samples/eventhubs/python/scripts/README.md
+++ b/samples/eventhubs/python/scripts/README.md
@@ -1,7 +1,7 @@
 # Azure CLI deployment
 
 Deploys the payment fraud detection pipeline with the Azure CLI, then verifies and
-exercises it. Run `azlocal start-interception` first so every `az` call is routed to the
+exercises it. Run `lstk az start-interception` first so every `az` call is routed to the
 LocalStack Azure emulator.
 
 ## Scripts

--- a/samples/eventhubs/python/scripts/deploy.sh
+++ b/samples/eventhubs/python/scripts/deploy.sh
@@ -17,7 +17,7 @@
 #   Web App (Python)                       operations dashboard
 #
 # Everything runs against the LocalStack Azure emulator; no real cloud resources
-# are created. Run 'azlocal start-interception' first.
+# are created. Run 'lstk az start-interception' first.
 # =============================================================================
 
 # Variables

--- a/samples/eventhubs/python/src/dashboard/app.py
+++ b/samples/eventhubs/python/src/dashboard/app.py
@@ -40,6 +40,9 @@ SCHEMA_NAME = os.environ.get("SCHEMA_NAME", "PaymentEvent")
 API_VERSION = "2023-07-01"
 # Upper bound on a single alerts read, so a page refresh can never hang the worker thread.
 ALERT_READ_TIMEOUT_SECONDS = 15
+# How many alerts the table below the headline shows. The page labels itself with this, so the
+# label cannot drift from the list it describes - and the headline total is deliberately separate.
+ALERT_PAGE_SIZE = 25
 
 
 def eventhub_connection() -> str:
@@ -60,32 +63,30 @@ def _namespace_host(conn_str: str) -> str:
 
 
 def hub_total(hub_name: str) -> int:
-    """Total events in a hub, from partition metadata.
+    """Events ever enqueued in a hub, summed from per-partition runtime metadata.
 
     Counting by reading a hub does not scale and, worse, is bounded by whatever page size the
     reader uses - which would silently turn a headline count into a page size. The runtime
     metadata gives the real total without consuming anything.
+
+    High-water mark, not live occupancy: `last_enqueued_sequence_number` is the last event
+    *enqueued*, so this errs high once retention expires events - it never falls. For events still
+    retained the figure would be `last_enqueued_sequence_number - beginning_sequence_number + 1`.
+
+    A read failure is deliberately not caught. Returning 0 would be indistinguishable from an empty
+    hub, and since 0 is a real value the page's fallback would not fire: the headline would read 0
+    above a list of alerts, then flash a delta the size of the whole hub on the next good refresh.
+    https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.eventhubs.partitionproperties
     """
-    conn = eventhub_connection()
-    if not conn:
-        return 0
-    try:
-        client = EventHubProducerClient.from_connection_string(conn, eventhub_name=hub_name)
-        with client:
-            return sum(
-                client.get_partition_properties(partition_id)["last_enqueued_sequence_number"] + 1
-                for partition_id in client.get_partition_ids()
-            )
-    except Exception:
-        return 0
+    return sum(row["events"] for row in partition_snapshot(hub_name))
 
 
-def partition_snapshot() -> list[dict]:
-    """Live per-partition head positions for the payments hub."""
+def partition_snapshot(hub_name: str = EVENT_HUB_NAME) -> list[dict]:
+    """Live per-partition head positions for a hub."""
     conn = eventhub_connection()
     if not conn:
         return []
-    client = EventHubProducerClient.from_connection_string(conn, eventhub_name=EVENT_HUB_NAME)
+    client = EventHubProducerClient.from_connection_string(conn, eventhub_name=hub_name)
     rows = []
     with client:
         for partition_id in client.get_partition_ids():
@@ -144,7 +145,7 @@ def checkpoint_snapshot(partitions: list[dict]) -> list[dict]:
     return sorted(rows, key=lambda row: row["partition"])
 
 
-def recent_alerts(limit: int = 25) -> list[dict]:
+def recent_alerts(limit: int = ALERT_PAGE_SIZE) -> list[dict]:
     """Read the fraud-alerts hub from the beginning (the sample keeps volumes small)."""
     conn = eventhub_connection()
     if not conn:
@@ -287,7 +288,11 @@ def schema_snapshot() -> list[dict]:
 
 @app.route("/")
 def index():
-    return render_template("index.html", refreshed=datetime.now(UTC).strftime("%H:%M:%S"))
+    return render_template(
+        "index.html",
+        refreshed=datetime.now(UTC).strftime("%H:%M:%S"),
+        alert_page_size=ALERT_PAGE_SIZE,
+    )
 
 
 @app.route("/api/overview")

--- a/samples/eventhubs/python/src/dashboard/app.py
+++ b/samples/eventhubs/python/src/dashboard/app.py
@@ -59,6 +59,27 @@ def _namespace_host(conn_str: str) -> str:
     return ""
 
 
+def hub_total(hub_name: str) -> int:
+    """Total events in a hub, from partition metadata.
+
+    Counting by reading a hub does not scale and, worse, is bounded by whatever page size the
+    reader uses - which would silently turn a headline count into a page size. The runtime
+    metadata gives the real total without consuming anything.
+    """
+    conn = eventhub_connection()
+    if not conn:
+        return 0
+    try:
+        client = EventHubProducerClient.from_connection_string(conn, eventhub_name=hub_name)
+        with client:
+            return sum(
+                client.get_partition_properties(partition_id)["last_enqueued_sequence_number"] + 1
+                for partition_id in client.get_partition_ids()
+            )
+    except Exception:
+        return 0
+
+
 def partition_snapshot() -> list[dict]:
     """Live per-partition head positions for the payments hub."""
     conn = eventhub_connection()
@@ -280,6 +301,8 @@ def overview():
             "alert_hub": ALERT_HUB_NAME,
             "consumer_group": FRAUD_CONSUMER_GROUP,
             "total_events": sum(row["events"] for row in partitions),
+            # The real number of alerts, not the length of the page below it.
+            "total_alerts": hub_total(ALERT_HUB_NAME),
             "partitions": partitions,
             "checkpoints": checkpoint_snapshot(partitions),
             "alerts": recent_alerts(),

--- a/samples/eventhubs/python/src/dashboard/static/style.css
+++ b/samples/eventhubs/python/src/dashboard/static/style.css
@@ -29,3 +29,31 @@ table thead th {
   color: #6c757d;
   font-weight: 600;
 }
+
+/* A refresh that changes nothing should look different from one that does: headline numbers
+   flash and show how much they moved, so cause and effect are visible while demonstrating. */
+.stat-changed {
+  animation: stat-flash 1.2s ease-out;
+}
+
+@keyframes stat-flash {
+  0%   { background: #fff3cd; }
+  100% { background: transparent; }
+}
+
+.stat-delta {
+  display: inline-block;
+  margin-left: .35rem;
+  padding: .1rem .4rem;
+  border-radius: .35rem;
+  font-size: .75rem;
+  font-weight: 700;
+  color: #0f5132;
+  background: #d1e7dd;
+  opacity: 0;
+  transition: opacity .3s ease-in;
+}
+
+.stat-delta.show {
+  opacity: 1;
+}

--- a/samples/eventhubs/python/src/dashboard/templates/index.html
+++ b/samples/eventhubs/python/src/dashboard/templates/index.html
@@ -20,21 +20,21 @@
     <div class="col-6 col-lg-3">
       <div class="card shadow-sm h-100"><div class="card-body">
         <div class="text-secondary small text-uppercase">Events ingested</div>
-        <div class="display-6" id="stat-events">-</div><span class="stat-delta"></span>
+        <div class="d-flex align-items-baseline"><div class="display-6" id="stat-events">-</div><span class="stat-delta"></span></div>
         <div class="small text-secondary" id="stat-hub"></div>
       </div></div>
     </div>
     <div class="col-6 col-lg-3">
       <div class="card shadow-sm h-100"><div class="card-body">
         <div class="text-secondary small text-uppercase">Fraud alerts</div>
-        <div class="display-6 text-danger" id="stat-alerts">-</div><span class="stat-delta"></span>
+        <div class="d-flex align-items-baseline"><div class="display-6 text-danger" id="stat-alerts">-</div><span class="stat-delta"></span></div>
         <div class="small text-secondary">hot path</div>
       </div></div>
     </div>
     <div class="col-6 col-lg-3">
       <div class="card shadow-sm h-100"><div class="card-body">
         <div class="text-secondary small text-uppercase">Capture archives</div>
-        <div class="display-6" id="stat-capture">-</div><span class="stat-delta"></span>
+        <div class="d-flex align-items-baseline"><div class="display-6" id="stat-capture">-</div><span class="stat-delta"></span></div>
         <div class="small text-secondary">cold path (Avro in Blob)</div>
       </div></div>
     </div>
@@ -70,7 +70,7 @@
 
     <div class="col-lg-7">
       <div class="card shadow-sm h-100">
-        <div class="card-header fw-semibold text-danger">Fraud alerts <span class="text-secondary small fw-normal">(25 most recent)</span></div>
+        <div class="card-header fw-semibold text-danger">Fraud alerts <span class="text-secondary small fw-normal">({{ alert_page_size }} most recent)</span></div>
         <div class="table-responsive" style="max-height: 340px; overflow-y: auto;">
           <table class="table table-sm mb-0">
             <thead><tr><th>Account</th><th>Amount</th><th>Merchant</th><th>Reasons</th></tr></thead>
@@ -131,7 +131,10 @@ function setStat(id, value) {
       if (badge) {
         badge.textContent = '+' + delta;
         badge.classList.add('show');
-        setTimeout(() => badge.classList.remove('show'), 4000);
+        // Cancel the previous hide: two changes less than the badge lifetime apart are normal at
+        // this refresh gap, and a stale timer would strip the badge the newer change just set.
+        clearTimeout(Number(badge.dataset.timer));
+        badge.dataset.timer = setTimeout(() => badge.classList.remove('show'), 4000);
       }
     }
   }
@@ -204,6 +207,11 @@ async function refreshLoop() {
   try {
     await refresh();
   } finally {
+    if (updated.textContent === 'updating...') {
+      // refresh() bailed out before stamping a time. Say so: leaving 'updating...' up makes a
+      // broken pipeline look permanently busy, which is the opposite of what this page is for.
+      updated.textContent = 'refresh failed - retrying';
+    }
     setTimeout(refreshLoop, REFRESH_GAP_MS);
   }
 }

--- a/samples/eventhubs/python/src/dashboard/templates/index.html
+++ b/samples/eventhubs/python/src/dashboard/templates/index.html
@@ -20,21 +20,21 @@
     <div class="col-6 col-lg-3">
       <div class="card shadow-sm h-100"><div class="card-body">
         <div class="text-secondary small text-uppercase">Events ingested</div>
-        <div class="display-6" id="stat-events">-</div>
+        <div class="display-6" id="stat-events">-</div><span class="stat-delta"></span>
         <div class="small text-secondary" id="stat-hub"></div>
       </div></div>
     </div>
     <div class="col-6 col-lg-3">
       <div class="card shadow-sm h-100"><div class="card-body">
         <div class="text-secondary small text-uppercase">Fraud alerts</div>
-        <div class="display-6 text-danger" id="stat-alerts">-</div>
+        <div class="display-6 text-danger" id="stat-alerts">-</div><span class="stat-delta"></span>
         <div class="small text-secondary">hot path</div>
       </div></div>
     </div>
     <div class="col-6 col-lg-3">
       <div class="card shadow-sm h-100"><div class="card-body">
         <div class="text-secondary small text-uppercase">Capture archives</div>
-        <div class="display-6" id="stat-capture">-</div>
+        <div class="display-6" id="stat-capture">-</div><span class="stat-delta"></span>
         <div class="small text-secondary">cold path (Avro in Blob)</div>
       </div></div>
     </div>
@@ -70,7 +70,7 @@
 
     <div class="col-lg-7">
       <div class="card shadow-sm h-100">
-        <div class="card-header fw-semibold text-danger">Fraud alerts</div>
+        <div class="card-header fw-semibold text-danger">Fraud alerts <span class="text-secondary small fw-normal">(25 most recent)</span></div>
         <div class="table-responsive" style="max-height: 340px; overflow-y: auto;">
           <table class="table table-sm mb-0">
             <thead><tr><th>Account</th><th>Amount</th><th>Merchant</th><th>Reasons</th></tr></thead>
@@ -114,6 +114,30 @@ function escapeHtml(value) {
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+// Write a headline number and flash it when it moves, so a refresh that changes something
+// is obvious. Without this the page looks identical whether or not anything happened.
+function setStat(id, value) {
+  const element = document.getElementById(id);
+  const previous = element.dataset.value;
+  const next = String(value);
+  element.textContent = next;
+  if (previous !== undefined && previous !== next) {
+    element.classList.remove('stat-changed');
+    void element.offsetWidth;  // restart the animation
+    element.classList.add('stat-changed');
+    const delta = Number(next) - Number(previous);
+    if (Number.isFinite(delta) && delta > 0) {
+      const badge = element.parentElement.querySelector('.stat-delta');
+      if (badge) {
+        badge.textContent = '+' + delta;
+        badge.classList.add('show');
+        setTimeout(() => badge.classList.remove('show'), 4000);
+      }
+    }
+  }
+  element.dataset.value = next;
+}
+
 async function refresh() {
   let data;
   try {
@@ -122,10 +146,10 @@ async function refresh() {
     return;
   }
 
-  document.getElementById('stat-events').textContent = data.total_events ?? 0;
+  setStat('stat-events', data.total_events ?? 0);
   document.getElementById('stat-hub').textContent = data.event_hub || '';
-  document.getElementById('stat-alerts').textContent = (data.alerts || []).length;
-  document.getElementById('stat-capture').textContent = (data.capture_files || []).length;
+  setStat('stat-alerts', data.total_alerts ?? (data.alerts || []).length);
+  setStat('stat-capture', (data.capture_files || []).length);
   document.getElementById('stat-cg').textContent = data.consumer_group || '';
 
   const lags = (data.checkpoints || []).map(row => row.lag).filter(value => value !== null);
@@ -169,8 +193,22 @@ async function refresh() {
     'refreshed ' + new Date().toISOString().slice(11, 19) + ' UTC';
 }
 
-refresh();
-setInterval(refresh, 5000);
+// Reading both hubs takes several seconds, so the next refresh is scheduled only after the
+// previous one finishes. A fixed interval shorter than the request would overlap requests,
+// land responses out of order, and make the page appear to update at random moments.
+const REFRESH_GAP_MS = 3000;
+
+async function refreshLoop() {
+  const updated = document.getElementById('updated');
+  updated.textContent = 'updating...';
+  try {
+    await refresh();
+  } finally {
+    setTimeout(refreshLoop, REFRESH_GAP_MS);
+  }
+}
+
+refreshLoop();
 </script>
 </body>
 </html>

--- a/samples/eventhubs/python/terraform/README.md
+++ b/samples/eventhubs/python/terraform/README.md
@@ -5,7 +5,7 @@ application code with the Azure CLI.
 
 ## Prerequisites
 
-- The LocalStack Azure emulator is running and `azlocal start-interception` has been run.
+- The LocalStack Azure emulator is running and `lstk az start-interception` has been run.
 - `terraform` and `az` are on the PATH.
 
 The provider is already pointed at the emulator in `providers.tf`


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Two problems surfaced while demonstrating the Event Hubs sample, both of which make the dashboard actively misleading rather than merely plain.

The fraud alert count sat at 25 and never moved, no matter how many alerts were generated. It was not a stuck counter: the headline number was rendering the length of the recent-alerts list below it, which is capped at 25. So the sample's central claim — that fraud alerts accumulate as suspicious payments arrive — silently stopped being demonstrable exactly when it got interesting.

Second, a refresh that changed something looked identical to one that changed nothing. With the page polling on a timer, there was no way to tell which numbers had moved, or whether the pipeline was doing anything at all.

## Changes

- Added `hub_total()`, which reads the true event count for a hub from partition runtime metadata (summing `last_enqueued_sequence_number + 1` across partitions). This does not consume events and is not bounded by any page size — counting by reading the hub would not scale and would reintroduce the same class of bug. The overview payload now carries `total_alerts` from it, so the headline figure is the real total.
- The "Fraud alerts" card header now reads "(25 most recent)", making explicit that the list is a page while the headline stat is the total. That distinction is what was missing.
- Headline numbers flash when they change and show a `+N` delta badge for a few seconds, via a small `setStat()` helper and two CSS rules. Cause and effect are now visible during a demo without watching logs.

## Tests

Verified by hand against the running sample: alerts climb past 25 and keep climbing, the total matches the number of alerts actually published, and the flash plus delta badge fire only on refreshes where a value genuinely moved.

`hub_total()` follows the same `except Exception: return <empty>` idiom as the four other helpers in `app.py`, so a transient Event Hubs error degrades the affected figure instead of breaking the page.

## Related

Follow-up to the Event Hubs fraud detection sample (#104).

[SMF-790](https://linear.app/localstack/issue/SMF-790)
