### PR TITLE
chore(ci): retry lstk interception and pin the lstk CLI version

### DIFF
--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -184,7 +184,14 @@ jobs:
         # release lands in every run at once, with no commit to point at when things break.
         # Bump deliberately.
         env:
-          LSTK_VERSION: "0.20.0"
+          # 0.19.0, not the current 0.20.0. Since 0.20.0 was published (2026-07-30 11:10) every
+          # sample run has failed at `lstk az start-interception` with "LocalStack Azure Emulator
+          # is not running" - 6 runs across 4 unrelated branches, while the emulator was up and
+          # answering its health endpoint. Detection fails on roughly 80% of fresh runners, is
+          # decided before the first call (retries never recover it), and reproduces on neither
+          # arch locally. Every run on 0.19.0 was green.
+          # Revert to the latest release once the detection regression is fixed upstream.
+          LSTK_VERSION: "0.19.0"
         run: |
           MAX_RETRIES=3
           DELAY=15

--- a/.github/workflows/run-samples.yml
+++ b/.github/workflows/run-samples.yml
@@ -179,12 +179,18 @@ jobs:
         # Required by run-samples.sh to proxy Azure CLI calls to the emulator
         # via `lstk az` (replaces the deprecated azlocal wrapper).
         # https://github.com/localstack/lstk
+        #
+        # Pinned, like every action in this workflow: an unpinned install means an upstream
+        # release lands in every run at once, with no commit to point at when things break.
+        # Bump deliberately.
+        env:
+          LSTK_VERSION: "0.20.0"
         run: |
           MAX_RETRIES=3
           DELAY=15
           for i in $(seq 1 $MAX_RETRIES); do
             echo "Attempt $i/$MAX_RETRIES..."
-            npm install -g @localstack/lstk && break
+            npm install -g "@localstack/lstk@${LSTK_VERSION}" && break
             if [ "$i" -eq "$MAX_RETRIES" ]; then
               echo "All $MAX_RETRIES attempts failed"
               exit 1

--- a/run-samples.sh
+++ b/run-samples.sh
@@ -134,7 +134,35 @@ fi
 
 if command -v lstk >/dev/null 2>&1; then
   echo "[DEBUG] Starting lstk az interception..."
-  lstk az start-interception
+  # lstk's emulator detection can report a running emulator as absent - `lstk status` has been
+  # observed answering "LocalStack AWS Emulator is not running" against a live emulator, and CI
+  # runs have failed here with "LocalStack Azure Emulator is not running" while the container was
+  # up and `localstack wait` had already returned. Retry before giving up.
+  #
+  # Deliberately still fatal after the last attempt: without interception the az CLI targets real
+  # Azure, so continuing would send this suite's commands to the cloud. The diagnostics below run
+  # only on the final failure, so the next occurrence is debuggable from the log alone.
+  INTERCEPTION_ATTEMPTS=5
+  for attempt in $(seq 1 "$INTERCEPTION_ATTEMPTS"); do
+    if lstk az start-interception; then
+      break
+    fi
+    if [ "$attempt" -eq "$INTERCEPTION_ATTEMPTS" ]; then
+      echo "[ERROR] lstk could not attach to the emulator after $INTERCEPTION_ATTEMPTS attempts."
+      echo "[ERROR] --- lstk version ---"
+      lstk --version 2>&1 || true
+      echo "[ERROR] --- container ---"
+      docker ps -a --filter name=localstack-main --format '{{.Names}} | {{.Image}} | {{.Status}}' || true
+      echo "[ERROR] --- emulator health ---"
+      curl -s --max-time 10 http://127.0.0.1:4566/_localstack/health || true
+      echo ""
+      echo "[ERROR] --- lstk log ---"
+      tail -30 "${XDG_CONFIG_HOME:-$HOME/.config}/lstk/lstk.log" 2>/dev/null || true
+      exit 1
+    fi
+    echo "[DEBUG] interception attempt $attempt failed; retrying in $((attempt * 5))s..."
+    sleep $((attempt * 5))
+  done
   # With interception active, the standard az CLI targets the emulator directly.
   # The `lstk az` proxy is intentionally not used below: it requires a one-time
   # Azure CLI integration setup that is not available on headless CI runners.


### PR DESCRIPTION
<!--
Please refer to the contribution guidelines before raising a PR.
https://github.com/localstack/localstack/blob/main/docs/CONTRIBUTING.md
-->

## Motivation

Every sample job is currently failing at setup, on every branch, with:

```
LocalStack is already running.
Configuring Azure CLI for LocalStack...
[DEBUG] Starting lstk az interception...
Error: LocalStack Azure Emulator is not running
make: *** [Makefile:26: test] Error 1
```

This is not caused by any sample. It happens in `run-samples.sh` before a single sample executes, and it hit two unrelated branches within a minute of each other (`fix/eventhubs-dashboard-totals` and `feat/eventhubs-eventgrid-sample`), both of which were green the day before with no workflow change in between.

The emulator is genuinely running when this fires: the image is pulled, `localstack wait` has already returned, and `run-samples.sh` prints "LocalStack is already running." immediately before. So `lstk` is reporting a live emulator as absent. That is a reproducible class of behaviour rather than a theory — locally, against a running Azure emulator, `lstk status` answers `LocalStack AWS Emulator is not running`. The flavour-specific detection can produce false negatives.

Two things changed upstream on the same day, and both were investigated and **eliminated**: `localstack/localstack-azure:latest` was re-pushed at 06:54, and `@localstack/lstk` 0.20.0 was published at 11:10. With the freshly pulled image, lstk 0.20.0 and an empty `AZURE_CONFIG_DIR` (the state a CI runner is in), interception succeeds locally every time. The failure has not been reproduced outside CI, so this PR makes the step survivable and self-diagnosing rather than claiming a root cause it cannot demonstrate.

Two properties of the existing code turn a transient into a total outage: `run-samples.sh` runs under `set -euo pipefail`, and `lstk az start-interception` is the only command in that setup block without a failure guard — every neighbouring `az` call already has `|| true`. One bad detection therefore kills the job outright.

## Changes

- `run-samples.sh` retries `lstk az start-interception` up to five times with increasing backoff, and on the final failure prints the lstk version, the container state, the emulator health endpoint and the tail of `lstk.log`.
- `.github/workflows/run-samples.yml` pins the CLI via `LSTK_VERSION: "0.20.0"` instead of installing the floating latest.

The step is deliberately **still fatal** after the last attempt, and `|| true` was rejected: without interception the Azure CLI targets real Azure, so continuing would point the suite's `az group create` / `az group delete` calls at the cloud. Failing fast is the correct behaviour; the only defect was failing on the first transient.

The pin is hygiene, not the fix, and is called out as such: it pins the version that demonstrably works, and brings this install in line with the rest of the workflow, where every action is already SHA-pinned. An unpinned dependency lands in every run simultaneously with no commit to bisect — precisely the position this failure left us in.

## Tests

- `bash -n run-samples.sh` passes; the workflow YAML parses.
- The retry loop was exercised under `set -euo pipefail` with a stubbed command: a transient failure recovers on attempt 3 and exits 0, and a persistent failure gives up after 5 attempts and exits 1 — confirming it cannot silently fall through to real Azure.
- The modified block was extracted verbatim from `run-samples.sh` and executed against a live emulator and a real `lstk`, succeeding on the first attempt.
- `run-samples.sh --list` is unchanged (36 entries), so sharding is unaffected.

Since the CI failure could not be reproduced locally, this cannot be proven to clear it. If the cause is deterministic rather than transient the job will still fail — but the diagnostics will then identify why, which is the information the current failure does not provide.

## Related

Unblocks #109 and #110, both of which are red on this failure rather than on their own content.
