### PR TITLE
Add mermaid architecture diagrams to samples missing an architecture image

### DIFF
--- a/samples/eventhubs-eventgrid/python/README.md
+++ b/samples/eventhubs-eventgrid/python/README.md
@@ -9,24 +9,41 @@ Blob Storage as Avro. The moment an archive lands, Event Hubs raises
 notification **into a second event hub**, and a Function App triggered on that hub downloads the
 archive, aggregates it per device, and writes summaries to a curated hub.
 
-```
- devices ──▶ telemetry hub ──── Capture (60s window) ────▶ Avro archive in Blob Storage
-                  │                                                    │
-                  │                        Microsoft.EventHub.CaptureFileCreated
-                  │                                                    ▼
-                  │                                    Event Grid system topic
-                  │                                                    │
-                  │                          subscription, EventHub destination
-                  │                                                    ▼
-                  │                                      capture-notifications hub
-                  │                                                    │
-                  │                                    Event Hubs trigger
-                  │                                                    ▼
-                  └───────────── archive read back ────────────  Function App
-                                                                       │
-                                                     Event Hubs output binding
-                                                                       ▼
-                                                                  curated hub
+## Architecture
+
+The following diagram illustrates the architecture of the solution:
+
+```mermaid
+flowchart LR
+    devices["Devices<br/>telemetry_producer.py"]
+
+    subgraph ehns["Event Hubs namespace"]
+        telemetry[["telemetry hub<br/>4 partitions, Capture enabled"]]
+        notifications[["capture-notifications hub<br/>2 partitions"]]
+        curated[["curated hub<br/>2 partitions"]]
+    end
+
+    subgraph storage["Storage Account"]
+        archive[("telemetry-archive container<br/>Avro archives")]
+    end
+
+    subgraph eventgrid["Event Grid"]
+        topic["System topic<br/>(over the namespace)"]
+        subscription["capture-to-eventhub subscription<br/>(Event Hub destination)"]
+    end
+
+    subgraph funcapp["Function App"]
+        processor["CaptureProcessor<br/>(Event Hubs trigger)"]
+    end
+
+    devices -->|"1: AMQP, partition key = device_id"| telemetry
+    telemetry -->|"2: Capture (60 s window, Avro)"| archive
+    telemetry -->|"3: Microsoft.EventHub.CaptureFileCreated"| topic
+    topic --> subscription
+    subscription -->|"4: delivered as an event"| notifications
+    notifications -->|"5: trigger (capture-processor group)"| processor
+    processor -->|"6: read archive (data.fileUrl)"| archive
+    processor -->|"7: per-device summaries (output binding)"| curated
 ```
 
 ## Why this shape

--- a/samples/eventhubs/python/README.md
+++ b/samples/eventhubs/python/README.md
@@ -10,28 +10,50 @@ The sample is built around the properties that make Event Hubs different from a 
 
 ## Architecture
 
-```
-  Producers (outside Azure)                LocalStack for Azure
-  ┌───────────────────────┐        ┌──────────────────────────────────────────────┐
-  │ POS terminals         │  AMQP  │  Event Hubs namespace (Standard, Kafka on)   │
-  │ producer_amqp.py      ├───────►│                                              │
-  │                       │        │   payments hub ─ 4 partitions ─── Capture ───┼──► Blob Storage
-  │ Legacy gateway        │ Kafka  │     consumer groups:                         │    Avro archives
-  │ producer_kafka.py     ├───────►│       fraud-detector ──┐  analytics  audit   │    (cold path)
-  │                       │        │                        │                     │
-  │ ATM / IoT devices     │ HTTPS  │                        ▼                     │
-  │ producer_http.py      ├───────►│              Function App (Python)           │
-  └───────────────────────┘        │              Event Hubs trigger              │
-                                   │              fraud rules ──────┐             │
-                                   │                                ▼             │
-                                   │   fraud-alerts hub ─ 2 partitions            │
-                                   │                                ▲             │
-                                   │   Key Vault: connection strings │            │
-                                   │   Schema Registry: Avro contract│            │
-                                   │   App Insights + Log Analytics  │            │
-                                   │                                 │            │
-                                   │   Web App ── operations dashboard            │
-                                   └──────────────────────────────────────────────┘
+The following diagram illustrates the architecture of the solution:
+
+```mermaid
+flowchart LR
+    subgraph producers["External producers"]
+        pos["POS terminals<br/>producer_amqp.py"]
+        gateway["Legacy gateway<br/>producer_kafka.py"]
+        atm["ATM / IoT devices<br/>producer_http.py"]
+    end
+
+    subgraph ehns["Event Hubs namespace (Standard, Kafka enabled)"]
+        payments[["payments hub<br/>4 partitions<br/>groups: fraud-detector, analytics, audit"]]
+        alerts[["fraud-alerts hub<br/>2 partitions"]]
+        registry["Schema Registry<br/>payments-schemas (Avro)"]
+    end
+
+    subgraph funcapp["Function App"]
+        detector["FraudDetector<br/>(Event Hubs trigger, batched)"]
+    end
+
+    subgraph storage["Storage Account"]
+        archive[("payments-archive container<br/>Avro archives, cold path")]
+        checkpoints[("checkpoint blobs")]
+    end
+
+    kv["Key Vault<br/>connection-string secrets<br/>(stored at deploy)"]
+    dashboard["Web App<br/>operations dashboard"]
+    monitor["Application Insights +<br/>Log Analytics"]
+
+    pos -->|"1: AMQP"| payments
+    gateway -->|"1: Kafka"| payments
+    atm -->|"1: HTTPS"| payments
+    producers -.->|"register Avro contract"| registry
+
+    payments -->|"2: trigger (fraud-detector group)"| detector
+    detector -->|"3: alerts (output binding)"| alerts
+    detector -.->|"checkpoints"| checkpoints
+    payments -->|"Capture (60 s / 10 MB, Avro)"| archive
+
+    dashboard -.->|"partition state, alerts, schemas"| ehns
+    dashboard -.->|"checkpoints, archives"| storage
+    ehns -.-> kv
+    funcapp -.->|"telemetry"| monitor
+    dashboard -.->|"telemetry"| monitor
 ```
 
 **Deployment flow.** The deploy script creates Log Analytics and Application Insights, a

--- a/samples/servicebus/java/README.md
+++ b/samples/servicebus/java/README.md
@@ -7,6 +7,23 @@ This sample demonstrates a Java Spring Boot application that sends and receives 
 
 ## Architecture
 
+The following diagram illustrates the architecture of the solution:
+
+```mermaid
+flowchart LR
+    subgraph host["Host machine"]
+        app["Spring Boot app<br/>ServiceBusSenderClient + @ServiceBusListener"]
+    end
+
+    subgraph sbns["Service Bus namespace (Standard)"]
+        queue[["myqueue"]]
+    end
+
+    app -->|"1: send 'Hello, World!'"| queue
+    queue -->|"2: deliver to @ServiceBusListener"| app
+    app -.->|"authenticates with AZURE_SERVICEBUS_CONNECTION_STRING"| sbns
+```
+
 The solution is composed of the following Azure resources:
 
 1. [Azure Resource Group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-cli): A logical container scoping all resources in this sample.


### PR DESCRIPTION
## Summary

- `samples/eventhubs/python`: replaces the ASCII-art diagram under `## Architecture` with a mermaid diagram (producers over AMQP/Kafka/HTTPS → `payments` hub → FraudDetector → `fraud-alerts`, plus Capture, checkpoints, dashboard, Key Vault, and App Insights/Log Analytics).
- `samples/eventhubs-eventgrid/python`: replaces the intro ASCII art with a proper `## Architecture` section and a mermaid diagram of the 7-step Capture → Event Grid → Functions pipeline.
- `samples/servicebus/java`: adds this sample's first diagram — the host-run Spring Boot app doing the send/receive round trip against `myqueue`.

All three diagrams were validated by rendering them with mermaid-cli; GitHub renders them natively. The style matches the existing url-shortener mermaid diagram (subgraphs as containers, numbered primary flow, dotted secondary edges) so each element maps 1:1 onto an Azure icon for the Visio version.

Visio-made architecture images (like the other 11 samples have) will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)