### PR TITLE
Upgrade all samples to azurerm provider 5.1.0

### DIFF
--- a/samples/aci-blob-storage/python/terraform/providers.tf
+++ b/samples/aci-blob-storage/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }
@@ -19,7 +19,7 @@ provider "azurerm" {
   # Set the hostname of the Azure Metadata Service (for example management.azure.com)
   # used to obtain the Cloud Environment when using LocalStack's Azure emulator.
   # This allows the provider to correctly identify the environment and avoid making calls to the real Azure endpoints.
-  metadata_host="localhost.localstack.cloud:4566"
+  metadata_host = "localhost.localstack.cloud:4566"
 
   # Set the subscription ID to a dummy value when using LocalStack's Azure emulator.
   subscription_id = "00000000-0000-0000-0000-000000000000"

--- a/samples/container-apps-blob-storage/python/terraform/main.tf
+++ b/samples/container-apps-blob-storage/python/terraform/main.tf
@@ -8,7 +8,7 @@ locals {
 
   # Secret NAMES referenced from more than one block, kept in one place so the
   # references never drift apart.
-  storage_conn_secret_name     = "storage-conn"
+  storage_conn_secret_name      = "storage-conn"
   registry_password_secret_name = "registry-password"
 }
 

--- a/samples/container-apps-blob-storage/python/terraform/providers.tf
+++ b/samples/container-apps-blob-storage/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }
@@ -19,7 +19,7 @@ provider "azurerm" {
   # Set the hostname of the Azure Metadata Service (for example management.azure.com)
   # used to obtain the Cloud Environment when using LocalStack's Azure emulator.
   # This allows the provider to correctly identify the environment and avoid making calls to the real Azure endpoints.
-  metadata_host="localhost.localstack.cloud:4566"
+  metadata_host = "localhost.localstack.cloud:4566"
 
   # Set the subscription ID to a dummy value when using LocalStack's Azure emulator.
   subscription_id = "00000000-0000-0000-0000-000000000000"

--- a/samples/eventhubs-eventgrid/python/terraform/main.tf
+++ b/samples/eventhubs-eventgrid/python/terraform/main.tf
@@ -140,12 +140,12 @@ resource "azurerm_eventhub_namespace_authorization_rule" "pipeline_listen" {
 # A system topic is how a subscriber reaches the events a resource raises about itself; Event Hubs
 # raises exactly one, Microsoft.EventHub.CaptureFileCreated.
 resource "azurerm_eventgrid_system_topic" "namespace" {
-  name                   = local.system_topic_name
-  resource_group_name    = azurerm_resource_group.main.name
-  location               = azurerm_resource_group.main.location
-  source_arm_resource_id = azurerm_eventhub_namespace.main.id
-  topic_type             = "Microsoft.Eventhub.Namespaces"
-  tags                   = var.tags
+  name                = local.system_topic_name
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  source_resource_id  = azurerm_eventhub_namespace.main.id
+  topic_type          = "Microsoft.Eventhub.Namespaces"
+  tags                = var.tags
 }
 
 # Delivering to an event hub turns the notification into a stream event, so an ordinary Event Hubs
@@ -154,7 +154,7 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "capture_to_eventhu
   name                  = var.event_subscription_name
   system_topic          = azurerm_eventgrid_system_topic.namespace.name
   resource_group_name   = azurerm_resource_group.main.name
-  eventhub_endpoint_id  = azurerm_eventhub.notifications.id
+  eventhub_id           = azurerm_eventhub.notifications.id
   event_delivery_schema = "EventGridSchema"
 }
 

--- a/samples/eventhubs-eventgrid/python/terraform/providers.tf
+++ b/samples/eventhubs-eventgrid/python/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/eventhubs/python/terraform/providers.tf
+++ b/samples/eventhubs/python/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/function-app-managed-identity/python/terraform/main.tf
+++ b/samples/function-app-managed-identity/python/terraform/main.tf
@@ -137,11 +137,3 @@ resource "azurerm_linux_function_app" "example" {
     ]
   }
 }
-
-# Create an app source control configuration
-resource "azurerm_app_service_source_control" "example" {
-  count    = var.repo_url == "" ? 0 : 1
-  app_id   = azurerm_linux_function_app.example.id
-  repo_url = var.repo_url
-  branch   = "main"
-}

--- a/samples/function-app-managed-identity/python/terraform/providers.tf
+++ b/samples/function-app-managed-identity/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }
@@ -19,7 +19,7 @@ provider "azurerm" {
   # Set the hostname of the Azure Metadata Service (for example management.azure.com) 
   # used to obtain the Cloud Environment when using LocalStack's Azure emulator. 
   # This allows the provider to correctly identify the environment and avoid making calls to the real Azure endpoints. 
-  metadata_host="localhost.localstack.cloud:4566"
+  metadata_host = "localhost.localstack.cloud:4566"
 
   # Set the subscription ID to a dummy value when using LocalStack's Azure emulator.
   subscription_id = "00000000-0000-0000-0000-000000000000"

--- a/samples/function-app-managed-identity/python/terraform/variables.tf
+++ b/samples/function-app-managed-identity/python/terraform/variables.tf
@@ -226,17 +226,6 @@ variable "public_network_access_enabled" {
   default     = true
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "managed_identity_type" {
   description = "Specifies the type of managed identity."
   type        = string

--- a/samples/function-app-service-bus/dotnet/terraform/main.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/main.tf
@@ -91,7 +91,7 @@ module "pe_subnet_network_security_group" {
   log_analytics_workspace_id = module.log_analytics_workspace.id
   tags                       = var.tags
   subnet_ids = {
-    (var.pe_subnet_name)     = module.virtual_network.subnet_ids[var.pe_subnet_name]
+    (var.pe_subnet_name) = module.virtual_network.subnet_ids[var.pe_subnet_name]
   }
 }
 
@@ -330,7 +330,6 @@ module "function_app" {
   python_version                = var.python_version
   managed_identity_type         = var.managed_identity_type
   managed_identity_id           = var.managed_identity_type == "UserAssigned" ? module.managed_identity.id : null
-  repo_url                      = var.repo_url
   log_analytics_workspace_id    = module.log_analytics_workspace.id
   tags                          = var.tags
 

--- a/samples/function-app-service-bus/dotnet/terraform/modules/application_insights/main.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/modules/application_insights/main.tf
@@ -1,14 +1,14 @@
 resource "azurerm_application_insights" "example" {
-  name                          = var.name
-  location                      = var.location
-  resource_group_name           = var.resource_group_name
-  tags                          = var.tags
-  application_type              = var.application_type
-  workspace_id                  = var.workspace_id
-  disable_ip_masking            = var.disable_ip_masking
-  local_authentication_disabled = var.local_authentication_disabled
-  internet_ingestion_enabled    = var.internet_ingestion_enabled
-  internet_query_enabled        = var.internet_query_enabled
+  name                         = var.name
+  location                     = var.location
+  resource_group_name          = var.resource_group_name
+  tags                         = var.tags
+  application_type             = var.application_type
+  workspace_id                 = var.workspace_id
+  ip_masking_enabled           = var.ip_masking_enabled
+  local_authentication_enabled = var.local_authentication_enabled
+  internet_ingestion_enabled   = var.internet_ingestion_enabled
+  internet_query_enabled       = var.internet_query_enabled
 
   lifecycle {
     ignore_changes = [

--- a/samples/function-app-service-bus/dotnet/terraform/modules/application_insights/variables.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/modules/application_insights/variables.tf
@@ -31,16 +31,16 @@ variable "tags" {
   default     = {}
 }
 
-variable "disable_ip_masking" {
-  description = "(Optional) Specifies whether IP masking is disabled."
+variable "ip_masking_enabled" {
+  description = "(Optional) Specifies whether IP masking is enabled."
   type        = bool
-  default     = false
+  default     = true
 }
 
-variable "local_authentication_disabled" {
-  description = "(Optional) Specifies whether local authentication is disabled."
+variable "local_authentication_enabled" {
+  description = "(Optional) Specifies whether local authentication is enabled."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "internet_ingestion_enabled" {

--- a/samples/function-app-service-bus/dotnet/terraform/modules/function_app/main.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/modules/function_app/main.tf
@@ -38,16 +38,6 @@ resource "azurerm_linux_function_app" "example" {
   }
 }
 
-# Deploy code from a public GitHub repo
-resource "azurerm_app_service_source_control" "example" {
-  count                  = var.repo_url == "" ? 0 : 1
-  app_id                 = azurerm_linux_function_app.example.id
-  repo_url               = var.repo_url
-  branch                 = var.repo_branch
-  use_manual_integration = true
-  use_mercurial          = false
-}
-
 resource "azurerm_monitor_diagnostic_setting" "example" {
   name                       = "DiagnosticsSettings"
   target_resource_id         = azurerm_linux_function_app.example.id

--- a/samples/function-app-service-bus/dotnet/terraform/modules/function_app/variables.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/modules/function_app/variables.tf
@@ -107,18 +107,6 @@ variable "app_settings" {
   default     = {}
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-}
-
-variable "repo_branch" {
-  description = "(Optional) Specifies the Git repository branch."
-  type        = string
-  default     = "main"
-}
-
 variable "tags" {
   description = "(Optional) Specifies the tags to be applied to the resources."
   type        = map(any)

--- a/samples/function-app-service-bus/dotnet/terraform/modules/private_dns_zone/main.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/modules/private_dns_zone/main.tf
@@ -13,10 +13,9 @@ resource "azurerm_private_dns_zone" "example" {
 resource "azurerm_private_dns_zone_virtual_network_link" "example" {
   for_each = var.virtual_networks_to_link
 
-  name                  = "link_to_${lower(basename(each.key))}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
-  virtual_network_id    = "/subscriptions/${each.value.subscription_id}/resourceGroups/${each.value.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${each.key}"
+  name                = "link_to_${lower(basename(each.key))}"
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
+  virtual_network_id  = "/subscriptions/${each.value.subscription_id}/resourceGroups/${each.value.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${each.key}"
 
   lifecycle {
     ignore_changes = [

--- a/samples/function-app-service-bus/dotnet/terraform/providers.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/function-app-service-bus/dotnet/terraform/variables.tf
+++ b/samples/function-app-service-bus/dotnet/terraform/variables.tf
@@ -235,17 +235,6 @@ variable "public_network_access_enabled" {
   default     = true
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "login_name" {
   description = "(Required) Specifies the login name for the application."
   type        = string

--- a/samples/function-app-storage-http/dotnet/terraform/main.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/main.tf
@@ -100,11 +100,3 @@ resource "azurerm_linux_function_app" "example" {
     ]
   }
 }
-
-# Create an app source control configuration
-resource "azurerm_app_service_source_control" "example" {
-  count    = var.repo_url == "" ? 0 : 1
-  app_id   = azurerm_linux_function_app.example.id
-  repo_url = var.repo_url
-  branch   = "main"
-}

--- a/samples/function-app-storage-http/dotnet/terraform/providers.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }
@@ -19,7 +19,7 @@ provider "azurerm" {
   # Set the hostname of the Azure Metadata Service (for example management.azure.com) 
   # used to obtain the Cloud Environment when using LocalStack's Azure emulator. 
   # This allows the provider to correctly identify the environment and avoid making calls to the real Azure endpoints. 
-  metadata_host="localhost.localstack.cloud:4566"
+  metadata_host = "localhost.localstack.cloud:4566"
 
   # Set the subscription ID to a dummy value when using LocalStack's Azure emulator.
   subscription_id = "00000000-0000-0000-0000-000000000000"

--- a/samples/function-app-storage-http/dotnet/terraform/terraform.tfvars
+++ b/samples/function-app-storage-http/dotnet/terraform/terraform.tfvars
@@ -1,4 +1,4 @@
-prefix              = "funchttp"
-location            = "westeurope"
-runtime_name        = "dotnet-isolated"
-dotnet_version      = "10.0"
+prefix         = "funchttp"
+location       = "westeurope"
+runtime_name   = "dotnet-isolated"
+dotnet_version = "10.0"

--- a/samples/function-app-storage-http/dotnet/terraform/variables.tf
+++ b/samples/function-app-storage-http/dotnet/terraform/variables.tf
@@ -202,17 +202,6 @@ variable "public_network_access_enabled" {
   default     = true
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "input_container_name" {
   description = "(Optional) Specifies the name of the input container."
   type        = string

--- a/samples/servicebus/java/terraform/providers.tf
+++ b/samples/servicebus/java/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/url-shortener/python/terraform/main.tf
+++ b/samples/url-shortener/python/terraform/main.tf
@@ -40,18 +40,18 @@ resource "azurerm_storage_account" "main" {
 }
 
 resource "azurerm_storage_table" "links" {
-  name                 = "links"
-  storage_account_name = azurerm_storage_account.main.name
+  name               = "links"
+  storage_account_id = azurerm_storage_account.main.id
 }
 
 resource "azurerm_storage_queue" "qrjobs" {
-  name                 = "qrjobs"
-  storage_account_name = azurerm_storage_account.main.name
+  name               = "qrjobs"
+  storage_account_id = azurerm_storage_account.main.id
 }
 
 resource "azurerm_storage_container" "qrcodes" {
   name                  = "qrcodes"
-  storage_account_name  = azurerm_storage_account.main.name
+  storage_account_id    = azurerm_storage_account.main.id
   container_access_type = "blob"
 }
 

--- a/samples/url-shortener/python/terraform/providers.tf
+++ b/samples/url-shortener/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/main.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/main.tf
@@ -178,7 +178,6 @@ module "web_app" {
   http2_enabled                 = var.http2_enabled
   minimum_tls_version           = var.minimum_tls_version
   python_version                = var.python_version
-  repo_url                      = var.repo_url
   log_analytics_workspace_id    = module.log_analytics_workspace.id
   tags                          = var.tags
 

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/modules/private_dns_zone/main.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/modules/private_dns_zone/main.tf
@@ -14,8 +14,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
   for_each = var.virtual_networks_to_link
 
   name                  = "link_to_${lower(basename(each.key))}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   virtual_network_id    = "/subscriptions/${each.value.subscription_id}/resourceGroups/${each.value.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${each.key}"
 
   lifecycle {

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/modules/web_app/main.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/modules/web_app/main.tf
@@ -32,16 +32,6 @@ resource "azurerm_linux_web_app" "example" {
   }
 }
 
-# Deploy code from a public GitHub repo
-resource "azurerm_app_service_source_control" "example" {
-  count                  = var.repo_url == "" ? 0 : 1
-  app_id                 = azurerm_linux_web_app.example.id
-  repo_url               = var.repo_url
-  branch                 = var.repo_branch
-  use_manual_integration = true
-  use_mercurial          = false
-}
-
 resource "azurerm_monitor_diagnostic_setting" "example" {
   name                       = "DiagnosticsSettings"
   target_resource_id         = azurerm_linux_web_app.example.id

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/modules/web_app/variables.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/modules/web_app/variables.tf
@@ -72,18 +72,6 @@ variable "app_settings" {
   default     = {}
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-}
-
-variable "repo_branch" {
-  description = "(Optional) Specifies the Git repository branch."
-  type        = string
-  default     = "main"
-}
-
 variable "tags" {
   description = "(Optional) Specifies the tags to be applied to the resources."
   type        = map(any)

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/providers.tf
@@ -1,12 +1,8 @@
 terraform {
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Pinned below 4.81.0: with azurerm 4.81 the Cosmos DB Mongo collection
-      # create/get requests hang against the current LocalStack Azure emulator
-      # (requests never complete, so the apply times out after 30 minutes).
-      # Bump back to =4.81.0 once the emulator handles the newer call pattern.
-      version = "=4.60.0"
+      source  = "hashicorp/azurerm"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/web-app-cosmosdb-mongodb-api/python/terraform/variables.tf
+++ b/samples/web-app-cosmosdb-mongodb-api/python/terraform/variables.tf
@@ -224,17 +224,6 @@ variable "public_network_access_enabled" {
   default     = true
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "login_name" {
   description = "(Required) Specifies the login name for the application."
   type        = string

--- a/samples/web-app-custom-image/python/terraform/main.tf
+++ b/samples/web-app-custom-image/python/terraform/main.tf
@@ -209,7 +209,6 @@ module "web_app" {
   docker_registry_url           = module.container_registry.login_server_url
   docker_registry_username      = module.container_registry.admin_username
   docker_registry_password      = module.container_registry.admin_password
-  repo_url                      = var.repo_url
   log_analytics_workspace_id    = module.log_analytics_workspace.id
   tags                          = var.tags
 

--- a/samples/web-app-custom-image/python/terraform/modules/container_registry/main.tf
+++ b/samples/web-app-custom-image/python/terraform/modules/container_registry/main.tf
@@ -19,6 +19,9 @@ resource "azurerm_container_registry" "example" {
     content {
       location = georeplications.value
       tags     = var.tags
+      # Required since azurerm 5.0; true matches Azure's default of serving replicas
+      # through the geo-replicated login server (regional endpoints stay opt-in).
+      global_endpoint_routing_enabled = true
     }
   }
 

--- a/samples/web-app-custom-image/python/terraform/modules/private_dns_zone/main.tf
+++ b/samples/web-app-custom-image/python/terraform/modules/private_dns_zone/main.tf
@@ -14,8 +14,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
   for_each = var.virtual_networks_to_link
 
   name                  = "link_to_${lower(basename(each.key))}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   virtual_network_id    = "/subscriptions/${each.value.subscription_id}/resourceGroups/${each.value.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${each.key}"
 
   lifecycle {

--- a/samples/web-app-custom-image/python/terraform/modules/web_app/main.tf
+++ b/samples/web-app-custom-image/python/terraform/modules/web_app/main.tf
@@ -39,16 +39,6 @@ resource "azurerm_linux_web_app" "example" {
   }
 }
 
-# Deploy code from a public GitHub repo
-resource "azurerm_app_service_source_control" "example" {
-  count                  = var.repo_url == "" ? 0 : 1
-  app_id                 = azurerm_linux_web_app.example.id
-  repo_url               = var.repo_url
-  branch                 = var.repo_branch
-  use_manual_integration = true
-  use_mercurial          = false
-}
-
 resource "azurerm_monitor_diagnostic_setting" "example" {
   name                       = "DiagnosticsSettings"
   target_resource_id         = azurerm_linux_web_app.example.id

--- a/samples/web-app-custom-image/python/terraform/modules/web_app/variables.tf
+++ b/samples/web-app-custom-image/python/terraform/modules/web_app/variables.tf
@@ -66,18 +66,6 @@ variable "app_settings" {
   default     = {}
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-}
-
-variable "repo_branch" {
-  description = "(Optional) Specifies the Git repository branch."
-  type        = string
-  default     = "main"
-}
-
 variable "tags" {
   description = "(Optional) Specifies the tags to be applied to the resources."
   type        = map(any)

--- a/samples/web-app-custom-image/python/terraform/providers.tf
+++ b/samples/web-app-custom-image/python/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/samples/web-app-custom-image/python/terraform/variables.tf
+++ b/samples/web-app-custom-image/python/terraform/variables.tf
@@ -175,17 +175,6 @@ variable "public_network_access_enabled" {
   default     = true
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "login_name" {
   description = "(Required) Specifies the login name for the application."
   type        = string

--- a/samples/web-app-managed-identity/python/terraform/main.tf
+++ b/samples/web-app-managed-identity/python/terraform/main.tf
@@ -116,13 +116,3 @@ resource "azurerm_linux_web_app" "example" {
     ]
   }
 }
-
-# Deploy code from a public GitHub repo
-resource "azurerm_app_service_source_control" "example" {
-  count                  = var.repo_url == "" ? 0 : 1
-  app_id                 = azurerm_linux_web_app.example.id
-  repo_url               = var.repo_url
-  branch                 = "main"
-  use_manual_integration = true
-  use_mercurial          = false
-}

--- a/samples/web-app-managed-identity/python/terraform/providers.tf
+++ b/samples/web-app-managed-identity/python/terraform/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/web-app-managed-identity/python/terraform/variables.tf
+++ b/samples/web-app-managed-identity/python/terraform/variables.tf
@@ -202,17 +202,6 @@ variable "webapp_public_network_access_enabled" {
   default     = true
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "managed_identity_type" {
   description = "Specifies the type of managed identity."
   type        = string

--- a/samples/web-app-mysql-flexible-server/python/terraform/main.tf
+++ b/samples/web-app-mysql-flexible-server/python/terraform/main.tf
@@ -182,7 +182,6 @@ module "web_app" {
   http2_enabled                 = var.http2_enabled
   minimum_tls_version           = var.minimum_tls_version
   python_version                = var.python_version
-  repo_url                      = var.repo_url
   log_analytics_workspace_id    = module.log_analytics_workspace.id
   tags                          = var.tags
 

--- a/samples/web-app-mysql-flexible-server/python/terraform/modules/private_dns_zone/main.tf
+++ b/samples/web-app-mysql-flexible-server/python/terraform/modules/private_dns_zone/main.tf
@@ -14,8 +14,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
   for_each = var.virtual_networks_to_link
 
   name                  = "link_to_${lower(basename(each.key))}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   virtual_network_id    = "/subscriptions/${each.value.subscription_id}/resourceGroups/${each.value.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${each.key}"
 
   lifecycle {

--- a/samples/web-app-mysql-flexible-server/python/terraform/modules/web_app/main.tf
+++ b/samples/web-app-mysql-flexible-server/python/terraform/modules/web_app/main.tf
@@ -32,16 +32,6 @@ resource "azurerm_linux_web_app" "example" {
   }
 }
 
-# Deploy code from a public GitHub repo
-resource "azurerm_app_service_source_control" "example" {
-  count                  = var.repo_url == "" ? 0 : 1
-  app_id                 = azurerm_linux_web_app.example.id
-  repo_url               = var.repo_url
-  branch                 = var.repo_branch
-  use_manual_integration = true
-  use_mercurial          = false
-}
-
 resource "azurerm_monitor_diagnostic_setting" "example" {
   name                       = "DiagnosticsSettings"
   target_resource_id         = azurerm_linux_web_app.example.id

--- a/samples/web-app-mysql-flexible-server/python/terraform/modules/web_app/variables.tf
+++ b/samples/web-app-mysql-flexible-server/python/terraform/modules/web_app/variables.tf
@@ -72,18 +72,6 @@ variable "app_settings" {
   default     = {}
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-}
-
-variable "repo_branch" {
-  description = "(Optional) Specifies the Git repository branch."
-  type        = string
-  default     = "main"
-}
-
 variable "tags" {
   description = "(Optional) Specifies the tags to be applied to the resources."
   type        = map(any)

--- a/samples/web-app-mysql-flexible-server/python/terraform/providers.tf
+++ b/samples/web-app-mysql-flexible-server/python/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/web-app-mysql-flexible-server/python/terraform/variables.tf
+++ b/samples/web-app-mysql-flexible-server/python/terraform/variables.tf
@@ -133,16 +133,6 @@ variable "public_network_access_enabled" {
   default = true
 }
 
-variable "repo_url" {
-  type    = string
-  default = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "login_name" {
   description = "Login name for the application (scopes activity ownership)."
   type        = string

--- a/samples/web-app-postgresql-flexible-server/python/terraform/main.tf
+++ b/samples/web-app-postgresql-flexible-server/python/terraform/main.tf
@@ -182,7 +182,6 @@ module "web_app" {
   http2_enabled                 = var.http2_enabled
   minimum_tls_version           = var.minimum_tls_version
   python_version                = var.python_version
-  repo_url                      = var.repo_url
   log_analytics_workspace_id    = module.log_analytics_workspace.id
   tags                          = var.tags
 

--- a/samples/web-app-postgresql-flexible-server/python/terraform/modules/private_dns_zone/main.tf
+++ b/samples/web-app-postgresql-flexible-server/python/terraform/modules/private_dns_zone/main.tf
@@ -14,8 +14,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
   for_each = var.virtual_networks_to_link
 
   name                  = "link_to_${lower(basename(each.key))}"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.example.name
+  private_dns_zone_id = azurerm_private_dns_zone.example.id
   virtual_network_id    = "/subscriptions/${each.value.subscription_id}/resourceGroups/${each.value.resource_group_name}/providers/Microsoft.Network/virtualNetworks/${each.key}"
 
   lifecycle {

--- a/samples/web-app-postgresql-flexible-server/python/terraform/modules/web_app/main.tf
+++ b/samples/web-app-postgresql-flexible-server/python/terraform/modules/web_app/main.tf
@@ -32,16 +32,6 @@ resource "azurerm_linux_web_app" "example" {
   }
 }
 
-# Deploy code from a public GitHub repo
-resource "azurerm_app_service_source_control" "example" {
-  count                  = var.repo_url == "" ? 0 : 1
-  app_id                 = azurerm_linux_web_app.example.id
-  repo_url               = var.repo_url
-  branch                 = var.repo_branch
-  use_manual_integration = true
-  use_mercurial          = false
-}
-
 resource "azurerm_monitor_diagnostic_setting" "example" {
   name                       = "DiagnosticsSettings"
   target_resource_id         = azurerm_linux_web_app.example.id

--- a/samples/web-app-postgresql-flexible-server/python/terraform/modules/web_app/variables.tf
+++ b/samples/web-app-postgresql-flexible-server/python/terraform/modules/web_app/variables.tf
@@ -72,18 +72,6 @@ variable "app_settings" {
   default     = {}
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-}
-
-variable "repo_branch" {
-  description = "(Optional) Specifies the Git repository branch."
-  type        = string
-  default     = "main"
-}
-
 variable "tags" {
   description = "(Optional) Specifies the tags to be applied to the resources."
   type        = map(any)

--- a/samples/web-app-postgresql-flexible-server/python/terraform/providers.tf
+++ b/samples/web-app-postgresql-flexible-server/python/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=4.81.0"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/web-app-postgresql-flexible-server/python/terraform/variables.tf
+++ b/samples/web-app-postgresql-flexible-server/python/terraform/variables.tf
@@ -133,16 +133,6 @@ variable "public_network_access_enabled" {
   default = true
 }
 
-variable "repo_url" {
-  type    = string
-  default = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "login_name" {
   description = "Login name for the application (scopes activity ownership)."
   type        = string

--- a/samples/web-app-sql-database/python/terraform/main.tf
+++ b/samples/web-app-sql-database/python/terraform/main.tf
@@ -136,7 +136,7 @@ resource "azurerm_key_vault" "example" {
   location                   = azurerm_resource_group.example.location
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  enable_rbac_authorization  = false
+  rbac_authorization_enabled = false
   soft_delete_retention_days = 7
   tags                       = var.tags
 
@@ -201,14 +201,4 @@ resource "azurerm_key_vault_certificate" "example" {
       ]
     }
   }
-}
-
-# Deploy code from a public GitHub repo
-resource "azurerm_app_service_source_control" "example" {
-  count                  = var.repo_url == "" ? 0 : 1
-  app_id                 = azurerm_linux_web_app.example.id
-  repo_url               = var.repo_url
-  branch                 = "main"
-  use_manual_integration = true
-  use_mercurial          = false
 }

--- a/samples/web-app-sql-database/python/terraform/providers.tf
+++ b/samples/web-app-sql-database/python/terraform/providers.tf
@@ -3,12 +3,8 @@ terraform {
 
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      # Pinned below 4.81.0: azurerm >= ~4.61 strictly parses the `sid` (secret id)
-      # returned for Key Vault certificates, and the LocalStack Azure emulator currently
-      # returns the certificate id in that field. Bump back to =4.81.0 once the emulator
-      # returns a proper `.../secrets/...` sid for certificates.
-      version = "=4.60.0"
+      source  = "hashicorp/azurerm"
+      version = "=5.1.0"
     }
   }
 }

--- a/samples/web-app-sql-database/python/terraform/variables.tf
+++ b/samples/web-app-sql-database/python/terraform/variables.tf
@@ -333,17 +333,6 @@ variable "webapp_public_network_access_enabled" {
   default     = true
 }
 
-variable "repo_url" {
-  description = "(Optional) Specifies the Git repository URL."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = var.repo_url == "" || can(regex("^https?://", var.repo_url))
-    error_message = "The repo_url must be empty or a valid HTTP/HTTPS URL."
-  }
-}
-
 variable "login_name" {
   description = "(Required) Specifies the login name for the application."
   type        = string


### PR DESCRIPTION
## Motivation

The samples were the lagging tested baseline: 13 pinned at =4.81.0 and two held back at =4.60.0 by emulator defects (Key Vault certificate `sid`, Cosmos Mongo LRO poll) that are fixed in the companion localstack-pro PR (together with a third defect — subnet `addressPrefixes` parsing — that this upgrade surfaced).

## Changes

- Every sample pinned at `=5.1.0` (15 terraform roots).
- Removed the dormant `azurerm_app_service_source_control` resources and their `repo_url`/`repo_branch` plumbing (28 files): azurerm 5.0 deleted the resource, and every sample kept it at `count = 0` (`repo_url` defaulted to `""` and was never set anywhere).
- azurerm 5.0 breaking-change migrations:
  - `azurerm_eventgrid_system_topic`: `source_arm_resource_id` → `source_resource_id`
  - `azurerm_eventgrid_system_topic_event_subscription`: `eventhub_endpoint_id` → `eventhub_id`
  - `azurerm_application_insights`: `disable_ip_masking` → `ip_masking_enabled`, `local_authentication_disabled` → `local_authentication_enabled` (polarity inverted with the rename; module variable defaults adjusted to preserve behavior)
  - `azurerm_storage_table`/`queue`/`container`: `storage_account_name` → `storage_account_id`
  - `azurerm_private_dns_zone_virtual_network_link`: zone name + resource group → `private_dns_zone_id` (five module copies)
  - `azurerm_container_registry` georeplications: new required `global_endpoint_routing_enabled = true` (matches Azure's default of serving replicas through the geo-replicated login server)
  - `azurerm_key_vault`: `enable_rbac_authorization` → `rbac_authorization_enabled` (now required)

## Tests

- All 15 terraform roots pass `terraform validate` on 5.1.0.
- Full CI-style sweep of all 14 TERRAFORM_SAMPLES deploys, run locally against a container built from the shipped localstack-azure image with the three emulator fixes overlaid: every sample's Terraform stage applies and destroys cleanly on azurerm 5.1.0. Three samples (aci-blob-storage, container-apps-blob-storage, web-app-cosmosdb-mongodb-api) pass their entire deploy.sh including az verification; the remainder stop only at post-apply app-build steps that need tools absent in the local environment (mvn, sqlcmd, mysql, psql, .NET 10 SDK, CI-built app zips) — all present in CI.
- Notably, the two previously-pinned samples now work on 5.1.0: web-app-cosmosdb-mongodb-api deploys fully (28 resources incl. the Mongo collection that used to hang), and web-app-sql-database applies incl. the Key Vault certificate that used to fail parsing.

## Sequencing

Merge AFTER the localstack-pro emulator fixes are in a published localstack/localstack-azure image — samples CI pulls `:latest`, and several samples fail against an image without the fixes (subnet creation, KV certificates, Cosmos Mongo).
